### PR TITLE
Add influxdb to Docker environment

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -36,3 +36,10 @@ services:
       -  ../../Cockpit:/usr/local/Cockpit
     ports:
       - "6001:6001"
+
+  influxdb:
+    image: influxdb:1.5-alpine
+    volumes:
+      - /tmp/cockpit/influxdb:/var/lib/influxdb
+    ports:
+      - "8086:8086"


### PR DESCRIPTION
# Resolves no open issue

**Does your pull request solve a problem? Please describe.**
no

**Does your pull request add a feature**
InfluxDB is added to the Docker environment as it is part of the server environment as well.
Adding InfluxDB as additional container keeps the production and development setups equivalent.

**Affected Component**
Docker setup, Cockpit Backend/App (Influx DB)

**Additional context**
The individual local Docker setup has to be restarted to include InfluxDB.

To stop a running docker environment simply press `ctrl + c`   

To start your docker environment run `sudo docker-compose up` while inside the hyrisecockpit/docker .