### PR TITLE
Add broader compatibility to compose file version

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,4 +1,4 @@
-version:  '3.7'
+version:  "3.6"
 
 services:
   backend:


### PR DESCRIPTION
# Resolves no open issue

**Does your pull request solve a problem? Please describe.**
docker-compose.yml version fails on certain/old Docker hosts. This fix adds broader compatibility by stepping one version lower and using double quotes instead of single quotes. 

**Affected Component**
Docker environment