### PR TITLE
Freeze werkzeug

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -32,6 +32,7 @@ flask-cors = "*"
 apscheduler = "*"
 influxdb = "*"
 flask-restx = "*"
+werkzeug = "==0.16.1"
 
 [requires]
 python_version = "3.8.1"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "cc7af6250a554d7458bd4c74b50a2fc66e6d5c0bb06d867cdd643c9b4f934b3b"
+            "sha256": "8e183e1dabc909723f32c1e7e918f2c6a5a14fd0dc614ce1b5af3d1e6ae7d709"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -332,10 +332,11 @@
         },
         "werkzeug": {
             "hashes": [
-                "sha256:7f91416b2e6902e39190552d5e05bc94c0d5034688753fceb28eaa9d16795027",
-                "sha256:834e6f4828864350b7c173a2be027f0a692512bbe9d7ddd52da8e29ff991a726"
+                "sha256:1e0dedc2acb1f46827daa2e399c1485c8fa17c0d8e70b6b875b4e7f54bf408d2",
+                "sha256:b353856d37dec59d6511359f97f6a4b2468442e454bd1c98298ddce53cac1f04"
             ],
-            "version": "==1.0.0rc1"
+            "index": "pypi",
+            "version": "==0.16.1"
         }
     },
     "develop": {
@@ -463,11 +464,11 @@
         },
         "flake8-bugbear": {
             "hashes": [
-                "sha256:3f11243dc710486449fac3be776ac2723786ed544fc0734f6134935ded82a1e9",
-                "sha256:cc73c885e2c605dc89073afc16e308bba987098a9507023aa24590bd06ebd786"
+                "sha256:a3ddc03ec28ba2296fc6f89444d1c946a6b76460f859795b35b77d4920a51b63",
+                "sha256:bd02e4b009fb153fe6072c31c52aeab5b133d508095befb2ffcf3b41c4823162"
             ],
             "index": "pypi",
-            "version": "==20.1.3"
+            "version": "==20.1.4"
         },
         "flake8-comprehensions": {
             "hashes": [

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -23,7 +23,7 @@ coverage==5.0.3
 entrypoints==0.3
 eradicate==1.0
 filelock==3.0.12
-flake8-bugbear==20.1.3
+flake8-bugbear==20.1.4
 flake8-comprehensions==3.2.2
 flake8-eradicate==0.2.4
 flake8-polyfill==1.0.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -37,4 +37,4 @@ requests==2.22.0
 six==1.14.0
 tzlocal==2.0.0
 urllib3==1.25.8
-werkzeug==1.0.0rc1
+werkzeug==0.16.1


### PR DESCRIPTION
# Resolves no issue

**Does your pull request solve a problem? Please describe:**  
[`flask-restx`](https://github.com/python-restx/flask-restx) had issues with [`werkzeug`](https://github.com/pallets/werkzeug) version `1.0.0rc1`. This would result in an `ImportError`, and the inability to start the backend.

**Does your pull request add a feature? Please describe:**  
No.

**Affected Component(s):**  
Environment

**Additional context:**  
Once it's safe to unfreeze, we should probably do so.