### PR TITLE
B fix shutdown worker

### DIFF
--- a/hyrisecockpit/database_manager/database.py
+++ b/hyrisecockpit/database_manager/database.py
@@ -124,8 +124,10 @@ def execute_queries(
     database_id: str,
 ) -> None:
     """Define workers work loop."""
+    # Allow exit without flush
     task_queue.cancel_join_thread()
     failed_task_queue.cancel_join_thread()
+
     with PoolCursor(connection_pool) as cur:
         with StorageCursor(
             STORAGE_HOST, STORAGE_PORT, STORAGE_USER, STORAGE_PASSWORD, database_id


### PR DESCRIPTION
# Resolves #233 

This PR is resolving the shutdown worker bug described in #233. It just implements the `cancel_join_thread()` call on the queues inside the child processes (workers). It allows the process to exit without flushing the queue. 
The `flush_queue` function in the `database` will now be called from a background job (Apscheduler). So the Backend keeps being responsive. This is necessary because the join of the processes in the JOB benchmark (with 10 Workers) can take up to 30 seconds (the queries seem to be quite heavy). 
In the future, we could maybe make this process faster by just terminating the worker (when we want to stop the workers from executing workload queries). In this case, we would not join the processes but instead just killing them. This wouldn't be so clean but faster. 

The following articles describe why we need to call `cancel_join_thread()` on the queues: 

https://docs.python.org/3/library/multiprocessing.html#multiprocessing-programming

https://docs.python.org/3/library/multiprocessing.html

