### PR TITLE
Add Stale bot config

### DIFF
--- a/.github/.stale.yml
+++ b/.github/.stale.yml
@@ -1,0 +1,17 @@
+# Number of days of inactivity before an issue becomes stale
+daysUntilStale: 30
+# Number of days of inactivity before a stale issue is closed
+daysUntilClose: 7
+# Issues with these labels will never be considered stale
+exemptLabels:
+  - pinned
+  - security
+# Label to use when marking an issue as stale
+staleLabel: wontfix
+# Comment to post when marking an issue as stale. Set to `false` to disable
+markComment: >
+  This issue has been automatically marked as stale because it has not had
+  recent activity. It will be closed if no further activity occurs. Thank you
+  for your contributions.
+# Comment to post when closing a stale issue. Set to `false` to disable
+closeComment: true


### PR DESCRIPTION
# Resolves no open issue

**Does your pull request solve a problem? Please describe:**  
With the growing use of issues, we need to keep an overview about the things that need to be done.

**Does your pull request add a feature? Please describe:**  
The Stale bot labels and closes stale tickets and keeps our issue list current and clean.

**Affected Component(s):**  
`Github Issues`

**Additional context:** 
Pinned issues and the ones labeled with security won't be closed.
Issues untouched for 30 days get labeled stale (wontfix label is used).
Issues can be labeled as stale (via wontfix label) manually.
Issues with wontfix label get closed after 7 days by the bot.
