### PR TITLE
Build plugins in Container

### DIFF
--- a/hyrise/Dockerfile
+++ b/hyrise/Dockerfile
@@ -10,5 +10,5 @@ RUN cd /usr/local/ && git clone https://github.com/hyrise/hyrise.git hyrise\
     && mkdir cmake-build-release \
     && cd cmake-build-release \
     && CXXFLAGS=-fdiagnostics-color=always cmake -DENABLE_NUMA_SUPPORT=Off -DCMAKE_BUILD_TYPE=Release .. \
-    && make hyriseConsole hyriseServer
+    && make hyriseConsole hyriseServer CompressionPlugin ClusteringPlugin
 


### PR DESCRIPTION
# Resolves missing Plugins in Container

**Does your pull request solve a problem? Please describe:**  
Currently there are no plugins used inside the Hyrise Container, this PR changes it.

**Affected Component(s):**  
`Docker:Hyrise`
