### PR TITLE
B/Log queue length values to InfluxDB

### DIFF
--- a/hyrisecockpit/database_manager/background_scheduler.py
+++ b/hyrisecockpit/database_manager/background_scheduler.py
@@ -83,18 +83,17 @@ class BackgroundJobManager(object):
 
     def _update_queue_length(self) -> None:
         queue_length: int = self._worker_pool.get_queue_length()
-        if queue_length > 0:
-            time_stamp: int = int(time()) * 1_000_000_000
-            with StorageCursor(
-                self._storage_host,
-                self._storage_port,
-                self._storage_user,
-                self._storage_password,
-                self._database_id,
-            ) as log:
-                log.log_meta_information(
-                    "queue_length", {"queue_length": queue_length}, time_stamp,
-                )
+        time_stamp: int = int(time()) * 1_000_000_000
+        with StorageCursor(
+            self._storage_host,
+            self._storage_port,
+            self._storage_user,
+            self._storage_password,
+            self._database_id,
+        ) as log:
+            log.log_meta_information(
+                "queue_length", {"queue_length": queue_length}, time_stamp,
+            )
 
     def _update_krueger_data(self) -> None:
         time_stamp = time_ns()

--- a/hyrisecockpit/database_manager/background_scheduler.py
+++ b/hyrisecockpit/database_manager/background_scheduler.py
@@ -3,7 +3,7 @@
 from copy import deepcopy
 from json import dumps
 from multiprocessing import Process, Value
-from time import time_ns
+from time import time, time_ns
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 from apscheduler.schedulers.background import BackgroundScheduler
@@ -14,6 +14,7 @@ from psycopg2.extensions import AsIs
 
 from .cursor import PoolCursor, StorageCursor
 from .table_names import table_names as _table_names
+from .worker_pool import WorkerPool
 
 
 class BackgroundJobManager(object):
@@ -25,6 +26,7 @@ class BackgroundJobManager(object):
         database_blocked: Value,
         connection_pool: pool,
         loaded_tables: Dict[str, Optional[str]],
+        worker_pool: WorkerPool,
         storage_host: str,
         storage_password: str,
         storage_port: str,
@@ -34,6 +36,7 @@ class BackgroundJobManager(object):
         self._database_id: str = database_id
         self._database_blocked: Value = database_blocked
         self._connection_pool: pool = connection_pool
+        self._worker_pool: WorkerPool = worker_pool
         self._storage_host: str = storage_host
         self._storage_password: str = storage_password
         self._storage_port: str = storage_port
@@ -60,6 +63,9 @@ class BackgroundJobManager(object):
         self._update_plugin_log_job = self._scheduler.add_job(
             func=self._update_plugin_log, trigger="interval", seconds=1,
         )
+        self._update_queue_length_job = self._scheduler.add_job(
+            func=self._update_queue_length, trigger="interval", seconds=1,
+        )
 
     def start(self) -> None:
         """Start background scheduler."""
@@ -72,7 +78,23 @@ class BackgroundJobManager(object):
         self._update_chunks_data_job.remove()
         self._update_storage_data_job.remove()
         self._update_plugin_log_job.remove()
+        self._update_queue_length_job.remove()
         self._scheduler.shutdown()
+
+    def _update_queue_length(self) -> None:
+        queue_length: int = self._worker_pool.get_queue_length()
+        if queue_length > 0:
+            time_stamp: int = int(time()) * 1_000_000_000
+            with StorageCursor(
+                self._storage_host,
+                self._storage_port,
+                self._storage_user,
+                self._storage_password,
+                self._database_id,
+            ) as log:
+                log.log_meta_information(
+                    "queue_length", {"queue_length": queue_length}, time_stamp,
+                )
 
     def _update_krueger_data(self) -> None:
         time_stamp = time_ns()

--- a/hyrisecockpit/database_manager/database.py
+++ b/hyrisecockpit/database_manager/database.py
@@ -49,22 +49,23 @@ class Database(object):
         self._loaded_tables: Dict[
             str, Optional[str]
         ] = self.create_empty_loaded_tables()
-        self._background_scheduler: BackgroundJobManager = BackgroundJobManager(
-            self._id,
-            self._database_blocked,
-            self._connection_pool,
-            self._loaded_tables,
-            storage_host,
-            storage_password,
-            storage_port,
-            storage_user,
-        )
         self._worker_pool: WorkerPool = WorkerPool(
             self._connection_pool,
             self.number_workers,
             self._id,
             workload_publisher_url,
             self._database_blocked,
+        )
+        self._background_scheduler: BackgroundJobManager = BackgroundJobManager(
+            self._id,
+            self._database_blocked,
+            self._connection_pool,
+            self._loaded_tables,
+            self._worker_pool,
+            storage_host,
+            storage_password,
+            storage_port,
+            storage_user,
         )
         self._background_scheduler.start()
         self._background_scheduler.load_tables(self._default_tables)

--- a/tests/database_manager/test_background_scheduler.py
+++ b/tests/database_manager/test_background_scheduler.py
@@ -59,7 +59,7 @@ def get_mocked_storage_cursor(*args):
 
 
 def get_mocked_worker_pool(*args) -> MagicMock:
-    """Return fake storage cursor."""
+    """Return fake worker pool."""
     worker_pool: MagicMock = MagicMock()
     worker_pool.get_queue_length.return_value = 0
     return worker_pool

--- a/tests/database_manager/test_background_scheduler.py
+++ b/tests/database_manager/test_background_scheduler.py
@@ -58,6 +58,13 @@ def get_mocked_storage_cursor(*args):
     return mocked_storage_cursor_constructor
 
 
+def get_mocked_worker_pool(*args) -> MagicMock:
+    """Return fake storage cursor."""
+    worker_pool: MagicMock = MagicMock()
+    worker_pool.get_queue_length.return_value = 0
+    return worker_pool
+
+
 def get_mocked_pool_cursor(*args):
     """Return fake storage cursor."""
     mocked_pool_cursor_constructor: MagicMock = MagicMock()
@@ -84,11 +91,13 @@ class TestBackgroundJobManager:
     )
     def background_job_manager(self) -> BackgroundJobManager:
         """Get a new BackgrpundJobManager."""
+        worker_pool: MagicMock = get_mocked_worker_pool()
         return BackgroundJobManager(
             database_id,
             get_database_blocked(),
             get_connection_pool(),
             fake_loaded_tables,
+            worker_pool,
             storage_host,
             storage_password,
             storage_port,
@@ -164,6 +173,7 @@ class TestBackgroundJobManager:
         background_job_manager._update_chunks_data_job = MagicMock()
         background_job_manager._update_storage_data_job = MagicMock()
         background_job_manager._update_plugin_log_job = MagicMock()
+        background_job_manager._update_queue_length_job = MagicMock()
 
         background_job_manager.close()
 
@@ -172,6 +182,7 @@ class TestBackgroundJobManager:
         background_job_manager._update_chunks_data_job.remove.assert_called_once()
         background_job_manager._update_storage_data_job.remove.assert_called_once()
         background_job_manager._update_plugin_log_job.remove.assert_called_once()
+        background_job_manager._update_queue_length_job.remove.assert_called_once()
         mock_scheduler.shutdown.assert_called_once()
 
     @patch(

--- a/tests/database_manager/test_database.py
+++ b/tests/database_manager/test_database.py
@@ -9,6 +9,7 @@ from psycopg2 import pool
 from pytest import fixture
 
 from hyrisecockpit.database_manager.database import Database
+from hyrisecockpit.database_manager.worker_pool import WorkerPool
 
 database_id: str = "MongoDB forever"
 database_user: str = "Proform"
@@ -74,6 +75,7 @@ def get_fake_background_job_manager(
     database_blocked: ValueType,
     connection_pool: pool,
     loaded_tables: Dict[str, Optional[str]],
+    worker_pool: WorkerPool,
     storage_host: str,
     storage_password: str,
     storage_port: str,


### PR DESCRIPTION
# Resolves #number

**Does your pull request solve a problem? Please describe:**  
In order to provide historical data, we need to log queue length to InfluxDB.

**Does your pull request add a feature? Please describe:**  
Now, `BackgroundScheduler` logs queue length to InfluxDB every second.

**Affected Component(s):**  
`Database`, `BackgroundScheduler`

**Additional context:**  
The logged queue length data is not used in `App` yet, as it would change the interface of the endpoint. The endpoint will be changed in the historical data PR anyway.
