### PR TITLE
f/479-change-time-interval

### DIFF
--- a/hyrisecockpit/frontend/src/components/charts/Barchart.vue
+++ b/hyrisecockpit/frontend/src/components/charts/Barchart.vue
@@ -56,7 +56,7 @@ function useBarChartConfiguration(
         l: 70,
         r: 40,
         b: 70,
-        t: 10,
+        t: 20,
         pad: 0
       },
       paper_bgcolor: "rgba(0,0,0,0)"

--- a/hyrisecockpit/frontend/src/meta/components.ts
+++ b/hyrisecockpit/frontend/src/meta/components.ts
@@ -1,8 +1,11 @@
 import { SetupContext, Ref, computed } from "@vue/composition-api";
-import { MetricProps, ComparisonMetricData, Metric } from "../types/metrics";
-import { getMetricChartConfiguration } from "./metrics";
-import { useDataEvents } from "../meta/events";
-import { getMetricRequestTime, getMetricFetchType } from "@/meta/metrics";
+import { MetricProps, ComparisonMetricData, Metric } from "@/types/metrics";
+import { useDataEvents } from "@/meta/events";
+import {
+  getMetricRequestTime,
+  getMetricChartConfiguration,
+  getMetricDataType
+} from "@/meta/metrics";
 import { useFormatting } from "@/meta/formatting";
 
 export function useLineChartComponent(
@@ -51,24 +54,21 @@ export function useUpdatingInterval(
   const { formatDateWithoutMilliSec, formatDateToHHMMSS } = useFormatting();
   return computed(() => {
     let currentTimeStamp = formatDateWithoutMilliSec(new Date());
-    let previousTimeStamp = new Date(
-      currentTimeStamp.getTime() - getMetricRequestTime(metric)
+    let type = "";
+    const intervalTime = Math.floor(
+      getMetricRequestTime(metric) / Math.pow(10, 3)
     );
-    if (timestamps.value.length === 1) {
-      currentTimeStamp = timestamps.value[0];
-      previousTimeStamp = new Date(
-        timestamps.value[0].getTime() - getMetricRequestTime(metric)
-      );
-    }
-    if (timestamps.value.length > 1) {
+    if (timestamps.value.length > 0) {
       currentTimeStamp = timestamps.value[timestamps.value.length - 1];
-      previousTimeStamp =
-        getMetricFetchType(metric) === "modify"
-          ? timestamps.value[0]
-          : timestamps.value[timestamps.value.length - 2];
     }
-    return `${formatDateToHHMMSS(previousTimeStamp)} - ${formatDateToHHMMSS(
-      currentTimeStamp
-    )}`;
+    if (getMetricDataType(metric) === "interval") {
+      type =
+        intervalTime > 1
+          ? `Interval: last ${intervalTime} seconds`
+          : "Interval: last second";
+    } else {
+      type = `Snapshot: ${formatDateToHHMMSS(currentTimeStamp)}`;
+    }
+    return type;
   });
 }

--- a/hyrisecockpit/frontend/src/meta/metrics.ts
+++ b/hyrisecockpit/frontend/src/meta/metrics.ts
@@ -5,9 +5,10 @@ import {
   MetricValueState,
   MetricValueStateOrder,
   MetricDetailsConfiguration,
-  ChartConfiguration
-} from "../types/metrics";
-import { useDataTransformation } from "../services/transformationService";
+  ChartConfiguration,
+  DataType
+} from "@/types/metrics";
+import { useDataTransformation } from "@/services/transformationService";
 import { colorDefinition } from "./colors";
 import { FetchType } from "@/types/services";
 
@@ -18,7 +19,8 @@ const metricsMetadata: Record<Metric, MetricMetadata> = {
     base: "chunks_data",
     endpoint: monitorBackend + "chunks",
     component: "Access",
-    requestTime: 5000
+    requestTime: 5000,
+    dataType: "interval"
   },
   cpu: {
     fetchType: "modify",
@@ -27,6 +29,7 @@ const metricsMetadata: Record<Metric, MetricMetadata> = {
     endpoint: monitorBackend + "system",
     component: "CPU",
     requestTime: 1000,
+    dataType: "interval",
     staticAxesRange: {
       y: { max: 100 }
     }
@@ -37,7 +40,8 @@ const metricsMetadata: Record<Metric, MetricMetadata> = {
     base: "latency",
     endpoint: monitorBackend + "latency",
     component: "Latency",
-    requestTime: 1000
+    requestTime: 1000,
+    dataType: "interval"
   },
   executedQueryTypeProportion: {
     fetchType: "read",
@@ -45,7 +49,8 @@ const metricsMetadata: Record<Metric, MetricMetadata> = {
     base: "krueger_data",
     endpoint: monitorBackend + "krueger_data",
     component: "QueryTypeProportion",
-    requestTime: 2000
+    requestTime: 5000,
+    dataType: "interval"
   },
   generatedQueryTypeProportion: {
     fetchType: "read",
@@ -55,7 +60,8 @@ const metricsMetadata: Record<Metric, MetricMetadata> = {
     base: "krueger_data",
     endpoint: monitorBackend + "krueger_data",
     component: "QueryTypeProportion",
-    requestTime: 2000
+    requestTime: 5000,
+    dataType: "interval"
   },
   queueLength: {
     fetchType: "modify",
@@ -63,7 +69,8 @@ const metricsMetadata: Record<Metric, MetricMetadata> = {
     base: "queue_length",
     endpoint: monitorBackend + "queue_length",
     component: "QueueLength",
-    requestTime: 1000
+    requestTime: 1000,
+    dataType: "interval"
   },
   ram: {
     fetchType: "modify",
@@ -72,6 +79,7 @@ const metricsMetadata: Record<Metric, MetricMetadata> = {
     endpoint: monitorBackend + "system",
     component: "RAM",
     requestTime: 1000,
+    dataType: "interval",
     staticAxesRange: {
       y: { max: 100 }
     }
@@ -82,6 +90,7 @@ const metricsMetadata: Record<Metric, MetricMetadata> = {
     base: "storage",
     endpoint: monitorBackend + "storage",
     component: "Storage",
+    dataType: "snapshot",
     requestTime: 5000
   },
   throughput: {
@@ -90,14 +99,15 @@ const metricsMetadata: Record<Metric, MetricMetadata> = {
     base: "throughput",
     endpoint: monitorBackend + "throughput",
     component: "Throughput",
+    dataType: "interval",
     requestTime: 1000
   }
 };
 
 const metricDetailColor: Record<MetricValueState, string> = {
   average: colorDefinition.orange,
-  high: colorDefinition.red,
-  low: colorDefinition.green
+  high: colorDefinition.green,
+  low: colorDefinition.red
 };
 
 const metricValueStateOrder: Record<
@@ -222,6 +232,10 @@ export function getMetricRequestTime(metric: Metric): number {
 
 export function getMetricFetchType(metric: Metric): FetchType {
   return metricsMetadata[metric].fetchType;
+}
+
+export function getMetricDataType(metric: Metric): DataType {
+  return metricsMetadata[metric].dataType;
 }
 
 export function getMetricValueStateOrder(

--- a/hyrisecockpit/frontend/src/meta/metrics.ts
+++ b/hyrisecockpit/frontend/src/meta/metrics.ts
@@ -90,8 +90,8 @@ const metricsMetadata: Record<Metric, MetricMetadata> = {
     base: "storage",
     endpoint: monitorBackend + "storage",
     component: "Storage",
-    dataType: "snapshot",
-    requestTime: 5000
+    requestTime: 5000,
+    dataType: "snapshot"
   },
   throughput: {
     fetchType: "modify",
@@ -99,8 +99,8 @@ const metricsMetadata: Record<Metric, MetricMetadata> = {
     base: "throughput",
     endpoint: monitorBackend + "throughput",
     component: "Throughput",
-    dataType: "interval",
-    requestTime: 1000
+    requestTime: 1000,
+    dataType: "interval"
   }
 };
 

--- a/hyrisecockpit/frontend/src/types/metrics.ts
+++ b/hyrisecockpit/frontend/src/types/metrics.ts
@@ -66,6 +66,8 @@ interface AxesRange {
   };
 }
 
+export type DataType = "interval" | "snapshot";
+
 export interface MetricMetadata {
   fetchType: FetchType;
   transformationService: TransformationService;
@@ -73,6 +75,7 @@ export interface MetricMetadata {
   endpoint: string;
   component: string;
   requestTime: number;
+  dataType: DataType;
   staticAxesRange?: AxesRange;
 }
 


### PR DESCRIPTION
# Resolves #479

**Does your pull request solve a problem? Please describe:**  
It is not necessary to show the current time stamps of the data above the charts. Instead it is necessary to easily determine, what the displayed data means. Therefore we need to know which interval will be aggregated. 

**Does your pull request add a feature? Please describe:**  
This PR will replace the current time stamps with this information. For storage data we will instead show the time stamp of the last snapshot.

**Affected Component(s):**  
`Frontend`

![image](https://user-images.githubusercontent.com/49444254/78347607-09092480-75a1-11ea-9f23-76e69316a075.png)


