### PR TITLE
Add frontend to docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,6 +36,14 @@ services:
       - /tmp/cockpit/influxdb:/var/lib/influxdb
     ports:
       - "8086:8086"
+
+  frontend:
+    image: node:buster
+    command: bash -c "npm install && npm run build"
+    volumes:
+      - ./hyrisecockpit/frontend:/usr/local/Cockpit/hyrisecockpit/frontend
+    ports:
+      - "8080:8080"
   
   hyrise:
     image: hyrise:bensk1_multithreaded


### PR DESCRIPTION
**Does your pull request add a feature? Please describe:**  
Adds the frontend to the docker environment.

**Affected Component(s):**  
`Docker`, `Frontend`

**Additional context:**  
To run a specific part of the docker environment, simply run 
```
docker-compose up [backend | manager | generator | influxdb | frontend | hyrise]
```
Adding no service will run all of them