### PR TITLE
Add send of start and close worker ipc message to manager

### DIFF
--- a/hyrisecockpit/api/app/workload/service.py
+++ b/hyrisecockpit/api/app/workload/service.py
@@ -12,7 +12,8 @@ from hyrisecockpit.response import Response
 from .interface import WorkloadInterface
 from .model import Workload
 
-url = "127.0.0.1:8000"
+generator_url = "127.0.0.1"
+manager_url = "127.0.0.2"
 
 
 class WorkloadService:
@@ -20,7 +21,7 @@ class WorkloadService:
 
     @staticmethod
     @socket(REQ)
-    def __send_req(message: Request, socket: socket) -> Response:
+    def __send_req(message: Request, url: str, socket: socket) -> Response:
         socket.connect(url)
         socket.send_json(message)
         response: Response = socket.recv_json()
@@ -28,9 +29,16 @@ class WorkloadService:
         return response
 
     @staticmethod
-    def _send_message(message: Request) -> Response:
-        """Send an IPC message with data to a database interface, return the repsonse."""
-        response = WorkloadService.__send_req(message)
+    def _send_message_to_generator(message: Request) -> Response:
+        """Send an IPC message with data to a generator interface, return the repsonse."""
+        response = WorkloadService.__send_req(message, generator_url)
+        validate(instance=response, schema=response_schema)
+        return response
+
+    @staticmethod
+    def _send_message_to_manager(message: Request) -> Response:
+        """Send an IPC message with data to a manager interface, return the repsonse."""
+        response = WorkloadService.__send_req(message, manager_url)
         validate(instance=response, schema=response_schema)
         return response
 
@@ -40,7 +48,7 @@ class WorkloadService:
 
         Returns a list of all Workloads.
         """
-        response = cls._send_message(
+        response = cls._send_message_to_generator(
             Request(header=Header(message="get all workloads"), body={})
         )
         return [Workload(**interface) for interface in response["body"]["workloads"]]
@@ -52,7 +60,13 @@ class WorkloadService:
         Returns the created Workload.
         Returns None if a Workload with the given ID already exists.
         """
-        response = cls._send_message(
+        response = cls._send_message_to_manager(
+            Request(header=Header(message="start worker"), body={})
+        )
+        if response["header"]["status"] == 400:
+            return None
+
+        response = cls._send_message_to_generator(
             Request(header=Header(message="start workload"), body=dict(interface))
         )
         return (
@@ -68,7 +82,7 @@ class WorkloadService:
         Returns the Workload with the given ID.
         Returns None if a Workload with the given ID doesn't exist.
         """
-        response = cls._send_message(
+        response = cls._send_message_to_generator(
             Request(
                 header=Header(message="get workload"), body={"workload_id": workload_id}
             )
@@ -86,7 +100,13 @@ class WorkloadService:
         Returns the workload_id of the deleted Workload.
         Returns None if a Workload with the given ID doesn't exist.
         """
-        response = cls._send_message(
+        response = cls._send_message_to_manager(
+            Request(header=Header(message="close worker"), body={})
+        )
+        if response["header"]["status"] == 400:
+            return None
+
+        response = cls._send_message_to_generator(
             Request(
                 header=Header(message="delete workload"),
                 body={"workload_id": workload_id},
@@ -107,7 +127,7 @@ class WorkloadService:
         Returns the updated Workload.
         Returns None if a Workload with the given ID doesn't exist.
         """
-        response = cls._send_message(
+        response = cls._send_message_to_generator(
             Request(
                 header=Header(message="update workload"),
                 body={"workload_id": workload_id, "workload": dict(interface)},

--- a/hyrisecockpit/database_manager/manager.py
+++ b/hyrisecockpit/database_manager/manager.py
@@ -262,6 +262,7 @@ class DatabaseManager(object):
         return get_response(200)
 
     def _call_close_worker(self, body: Body) -> Response:
+        # TODO just close if no workload at all is running
         for database in self._databases.values():
             if not database.close_worker():
                 return get_response(400)


### PR DESCRIPTION
**Does your pull request solve a problem? Please describe:**  
At the moment we are not starting the worker while a workload is registered. This PR solves this issue by sending the `manager` an IPC message. 

**Affected Component(s):**  
`DatabaseManager`, `App`

**Additional context:**  
We still need to adjust the `Manager`. The Manager should only close the worker if no workload is running and only start the worker if no worker are running and a workload is running. 
