### PR TITLE
Add requirements check

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -24,3 +24,9 @@ jobs:
     - name: Run all python tests
       run: |
         pipenv run pytest tests/ --cov=hyrisecockpit --cov-fail-under=58
+    - name: Native requirements mirror pipenv requirements
+      run: |
+        pipenv run pipenv_to_requirements -o requirements_temp.txt -f && cmp -s requirements.txt requirements_temp.txt
+    - name: Native requirements-dev mirror pipenv-dev requirements
+      run: |
+        pipenv run pipenv_to_requirements -d requirements-dev_temp.txt -f && cmp -s requirements-dev.txt requirements-dev_temp.txt


### PR DESCRIPTION
# Resolves #189

**Does your pull request solve a problem? Please describe:**  
We agreed to generate frozen native requirements for our docker workflow.
If the `Pipfile` and `Pipfile.lock` change, the requirements files are generated manually.

**Does your pull request add a feature? Please describe:**  
Add a check to the GitHub Actions backend workflow whether the frozen native requirements mirror the `Pipfile.lock` requirements. They still have to be generated manually (`pipenv_to_requirements -f`).

**Affected Component(s):**  
GitHub Actions

**Additional context:**  
@cH3n7i