### PR TITLE
f/510-add-footprint-chart

### DIFF
--- a/hyrisecockpit/frontend/config.ts
+++ b/hyrisecockpit/frontend/config.ts
@@ -1,7 +1,10 @@
 const vm = "aurora";
 const port = "8000";
-//const backendUrl = `http://vm-${vm}.eaalab.hpi.uni-potsdam.de:${port}/`;
+// const backendUrl = `http://vm-${vm}.eaalab.hpi.uni-potsdam.de:${port}/`;
 const backendUrl = "http://127.0.0.1:3000/";
 
 export const monitorBackend = backendUrl + "monitor/";
 export const controlBackend = backendUrl + "control/";
+
+export const isInTestMode: boolean =
+  (window as any).Cypress || backendUrl.includes("127.0.0.1");

--- a/hyrisecockpit/frontend/config.ts
+++ b/hyrisecockpit/frontend/config.ts
@@ -1,7 +1,7 @@
 const vm = "aurora";
 const port = "8000";
-// const backendUrl = `http://vm-${vm}.eaalab.hpi.uni-potsdam.de:${port}/`;
-const backendUrl = "http://127.0.0.1:3000/";
+const backendUrl = `http://vm-${vm}.eaalab.hpi.uni-potsdam.de:${port}/`;
+//const backendUrl = "http://127.0.0.1:3000/";
 
 export const monitorBackend = backendUrl + "monitor/";
 export const controlBackend = backendUrl + "control/";

--- a/hyrisecockpit/frontend/config.ts
+++ b/hyrisecockpit/frontend/config.ts
@@ -1,6 +1,7 @@
 const vm = "aurora";
 const port = "8000";
-const backendUrl = `http://vm-${vm}.eaalab.hpi.uni-potsdam.de:${port}/`;
+//const backendUrl = `http://vm-${vm}.eaalab.hpi.uni-potsdam.de:${port}/`;
+const backendUrl = "http://127.0.0.1:3000/";
 
 export const monitorBackend = backendUrl + "monitor/";
 export const controlBackend = backendUrl + "control/";

--- a/hyrisecockpit/frontend/src/components/container/MetricTile.vue
+++ b/hyrisecockpit/frontend/src/components/container/MetricTile.vue
@@ -37,6 +37,7 @@ import QueueLength from "@/components/metrics/QueueLength.vue";
 import QueryTypeProportion from "@/components/metrics/QueryTypeProportion.vue";
 import Storage from "@/components/metrics/Storage.vue";
 import Access from "@/components/metrics/Access.vue";
+import MemoryFootprint from "@/components/metrics/MemoryFootprint.vue";
 import { getMetricTitle, getMetricComponent } from "../../meta/metrics";
 import {
   Metric,
@@ -69,6 +70,7 @@ export default defineComponent({
     QueryTypeProportion,
     Access,
     Storage,
+    MemoryFootprint,
     TimeInterval
   },
   props: {

--- a/hyrisecockpit/frontend/src/components/metrics/MemoryFootprint.vue
+++ b/hyrisecockpit/frontend/src/components/metrics/MemoryFootprint.vue
@@ -1,0 +1,50 @@
+<template>
+  <div>
+    <metric-details
+      v-if="showDetails"
+      :metric="metric"
+      :databases="selectedDatabases"
+      :decimal-digits="3"
+    />
+    <Linechart
+      :selected-databases="selectedDatabases"
+      :data="data"
+      :graph-id="graphId || 'memoryFootprint'"
+      :chart-configuration="chartConfiguration"
+      :max-value="maxValue"
+      :timestamps="timestamps"
+      :max-chart-width="maxChartWidth"
+    />
+  </div>
+</template>
+
+<script lang="ts">
+import {
+  defineComponent,
+  SetupContext,
+  onMounted,
+  computed,
+  Ref,
+  ref,
+  watch
+} from "@vue/composition-api";
+import Linechart from "../charts/Linechart.vue";
+import {
+  MetricProps,
+  MetricPropsValidation,
+  ComparisonMetricData
+} from "../../types/metrics";
+import MetricDetails from "../details/MetricDetails.vue";
+import { useLineChartComponent } from "../../meta/components";
+
+export default defineComponent({
+  name: "MemoryFootprint",
+  props: MetricPropsValidation,
+  components: { Linechart, MetricDetails },
+  setup(props: MetricProps, context: SetupContext): ComparisonMetricData {
+    return {
+      ...useLineChartComponent(props, context)
+    };
+  }
+});
+</script>

--- a/hyrisecockpit/frontend/src/components/metrics/QueryTypeProportion.vue
+++ b/hyrisecockpit/frontend/src/components/metrics/QueryTypeProportion.vue
@@ -41,7 +41,6 @@ export default defineComponent({
   props: MetricPropsValidation,
   setup(props: MetricProps, context: SetupContext): Data {
     const data = context.root.$metricController.data[props.metric];
-    console.log("qt", data);
     const transformedData = ref<any>([]);
     const metricMeta = getMetricMetadata(props.metric);
 

--- a/hyrisecockpit/frontend/src/components/metrics/QueryTypeProportion.vue
+++ b/hyrisecockpit/frontend/src/components/metrics/QueryTypeProportion.vue
@@ -41,17 +41,21 @@ export default defineComponent({
   props: MetricPropsValidation,
   setup(props: MetricProps, context: SetupContext): Data {
     const data = context.root.$metricController.data[props.metric];
+    console.log("qt", data);
     const transformedData = ref<any>([]);
     const metricMeta = getMetricMetadata(props.metric);
 
-    watch(data, () => {
-      if (Object.keys(data.value).length) {
-        transformedData.value = metricMeta.transformationService(
-          data.value,
-          props.selectedDatabases[0]
-        );
+    watch(
+      () => data.value,
+      () => {
+        if (Object.keys(data.value).length) {
+          transformedData.value = metricMeta.transformationService(
+            data.value,
+            props.selectedDatabases[0]
+          );
+        }
       }
-    });
+    );
 
     return {
       transformedData,

--- a/hyrisecockpit/frontend/src/components/metrics/Storage.vue
+++ b/hyrisecockpit/frontend/src/components/metrics/Storage.vue
@@ -64,7 +64,6 @@ export default defineComponent({
 
     watch(data, () => {
       if (Object.keys(data.value).length) {
-        console.log(data);
         storageData.value = metricMeta.transformationService(
           data.value,
           props.selectedDatabases[0]

--- a/hyrisecockpit/frontend/src/components/metrics/Storage.vue
+++ b/hyrisecockpit/frontend/src/components/metrics/Storage.vue
@@ -64,6 +64,7 @@ export default defineComponent({
 
     watch(data, () => {
       if (Object.keys(data.value).length) {
+        console.log(data);
         storageData.value = metricMeta.transformationService(
           data.value,
           props.selectedDatabases[0]

--- a/hyrisecockpit/frontend/src/controller/metricController.ts
+++ b/hyrisecockpit/frontend/src/controller/metricController.ts
@@ -3,7 +3,7 @@ import { computed, watch } from "@vue/composition-api";
 import { useMetricService } from "@/services/metricService";
 import { Metric, availableMetrics, MetricController } from "@/types/metrics";
 import { MetricService } from "@/types/services";
-import { getMetricRequestTime } from "@/meta/metrics";
+import { getMetricRequestTime, getMetricMetadata } from "@/meta/metrics";
 import { useFormatting } from "@/meta/formatting";
 
 type Interval = {
@@ -46,10 +46,32 @@ export function useMetricController(): MetricController {
 
   function setupServices(): Record<Metric, MetricService> {
     const services: any = {};
-    availableMetrics.forEach(metric => {
-      services[metric] = useMetricService([metric]);
+    getMetricsByEndpoint(availableMetrics).forEach(metrics => {
+      const metricService = useMetricService(metrics);
+      metrics.forEach(metric => {
+        services[metric] = metricService;
+      });
     });
     return services;
+  }
+
+  function getMetricsByEndpoint(newMetrics: Metric[]): Metric[][] {
+    return newMetrics.reduce(
+      (metricsByEndpoint: Metric[][], metric: Metric) => {
+        const correspondingMetrics = metricsByEndpoint.find(metrics =>
+          metrics
+            .map(detectedMetric => getMetricMetadata(detectedMetric).endpoint)
+            .includes(getMetricMetadata(metric).endpoint)
+        );
+        if (correspondingMetrics) {
+          correspondingMetrics.push(metric);
+        } else {
+          metricsByEndpoint.push([metric]);
+        }
+        return metricsByEndpoint;
+      },
+      [] as Metric[][]
+    );
   }
 
   function setupIntervals(): Record<Metric, Interval> {
@@ -64,8 +86,9 @@ export function useMetricController(): MetricController {
     return intervals;
   }
 
-  function start(metrics: Metric[], start?: Date, end?: Date): void {
-    metrics.forEach(metric => {
+  function start(newMetrics: Metric[], start?: Date, end?: Date): void {
+    getMetricsByEndpoint(newMetrics).forEach(metrics => {
+      const metric = metrics[0];
       metricServices[metric].getDataIfReady(start, end);
       metricIntervals[metric].id = setInterval(
         metricServices[metric].getDataIfReady,
@@ -88,7 +111,6 @@ export function useMetricController(): MetricController {
 
   function mapToData(services: Record<Metric, MetricService>): void {
     Object.entries(services).forEach(([metric, service]) => {
-      console.log(metric, service.maxValues[metric as Metric]);
       data[metric as Metric] = computed(() => service.data[metric]);
       maxValueData[metric as Metric] = computed(
         () => service.maxValues[metric as Metric]

--- a/hyrisecockpit/frontend/src/controller/metricController.ts
+++ b/hyrisecockpit/frontend/src/controller/metricController.ts
@@ -1,5 +1,5 @@
 import { eventBus } from "@/plugins/eventBus";
-import { computed } from "@vue/composition-api";
+import { computed, watch } from "@vue/composition-api";
 import { useMetricService } from "@/services/metricService";
 import { Metric, availableMetrics, MetricController } from "@/types/metrics";
 import { MetricService } from "@/types/services";
@@ -86,9 +86,17 @@ export function useMetricController(): MetricController {
     });
   }
 
+  watch(
+    () => data["cpu"],
+    () => {
+      console.log("cpu", data["cpu"]);
+    }
+  );
+
   function mapToData(services: Record<Metric, MetricService>): void {
     Object.entries(services).forEach(([metric, service]) => {
-      data[metric as Metric] = computed(() => service.data.value[metric]);
+      console.log(metric, service.maxValues.value[metric]);
+      data[metric as Metric] = computed(() => service.data[metric]);
       maxValueData[metric as Metric] = computed(
         () => service.maxValues.value[metric as Metric]
       );

--- a/hyrisecockpit/frontend/src/controller/metricController.ts
+++ b/hyrisecockpit/frontend/src/controller/metricController.ts
@@ -1,4 +1,5 @@
 import { eventBus } from "@/plugins/eventBus";
+import { computed } from "@vue/composition-api";
 import { useMetricService } from "@/services/metricService";
 import { Metric, availableMetrics, MetricController } from "@/types/metrics";
 import { MetricService } from "@/types/services";
@@ -46,7 +47,7 @@ export function useMetricController(): MetricController {
   function setupServices(): Record<Metric, MetricService> {
     const services: any = {};
     availableMetrics.forEach(metric => {
-      services[metric] = useMetricService(metric);
+      services[metric] = useMetricService([metric]);
     });
     return services;
   }
@@ -87,8 +88,10 @@ export function useMetricController(): MetricController {
 
   function mapToData(services: Record<Metric, MetricService>): void {
     Object.entries(services).forEach(([metric, service]) => {
-      data[metric as Metric] = service.data;
-      maxValueData[metric as Metric] = service.maxValue;
+      data[metric as Metric] = computed(() => service.data.value[metric]);
+      maxValueData[metric as Metric] = computed(
+        () => service.maxValues.value[metric as Metric]
+      );
       timestamps[metric as Metric] = service.timestamps;
     });
   }

--- a/hyrisecockpit/frontend/src/controller/metricController.ts
+++ b/hyrisecockpit/frontend/src/controller/metricController.ts
@@ -86,19 +86,12 @@ export function useMetricController(): MetricController {
     });
   }
 
-  watch(
-    () => data["cpu"],
-    () => {
-      console.log("cpu", data["cpu"]);
-    }
-  );
-
   function mapToData(services: Record<Metric, MetricService>): void {
     Object.entries(services).forEach(([metric, service]) => {
-      console.log(metric, service.maxValues.value[metric]);
+      console.log(metric, service.maxValues[metric as Metric]);
       data[metric as Metric] = computed(() => service.data[metric]);
       maxValueData[metric as Metric] = computed(
-        () => service.maxValues.value[metric as Metric]
+        () => service.maxValues[metric as Metric]
       );
       timestamps[metric as Metric] = service.timestamps;
     });

--- a/hyrisecockpit/frontend/src/helpers/methods.ts
+++ b/hyrisecockpit/frontend/src/helpers/methods.ts
@@ -1,3 +1,5 @@
+import { backendUrl } from "../../config";
+
 export function equals(array1: string[], array2: string[]): boolean {
   array1.forEach(table1 =>
     array2.forEach(table2 => {
@@ -9,4 +11,5 @@ export function equals(array1: string[], array2: string[]): boolean {
   return true;
 }
 
-export const isInTestMode: boolean = (window as any).Cypress;
+export const isInTestMode: boolean =
+  (window as any).Cypress || backendUrl.includes("127.0.0.1");

--- a/hyrisecockpit/frontend/src/helpers/methods.ts
+++ b/hyrisecockpit/frontend/src/helpers/methods.ts
@@ -1,5 +1,3 @@
-import { backendUrl } from "../../config";
-
 export function equals(array1: string[], array2: string[]): boolean {
   array1.forEach(table1 =>
     array2.forEach(table2 => {
@@ -10,6 +8,3 @@ export function equals(array1: string[], array2: string[]): boolean {
   );
   return true;
 }
-
-export const isInTestMode: boolean =
-  (window as any).Cypress || backendUrl.includes("127.0.0.1");

--- a/hyrisecockpit/frontend/src/meta/charts.ts
+++ b/hyrisecockpit/frontend/src/meta/charts.ts
@@ -12,8 +12,8 @@ export function useChartReactivity(
 
   function isValidData(data: any): boolean {
     return Array.isArray(data)
-      ? props.data.length !== 0 && databasesUpdated.value
-      : Object.keys(props.data).length !== 0 && databasesUpdated.value;
+      ? data.length !== 0 && databasesUpdated.value
+      : Object.keys(data).length !== 0 && databasesUpdated.value;
   }
 
   function isValidLayout(width: number): boolean {

--- a/hyrisecockpit/frontend/src/meta/components.ts
+++ b/hyrisecockpit/frontend/src/meta/components.ts
@@ -1,4 +1,4 @@
-import { SetupContext, Ref, computed } from "@vue/composition-api";
+import { SetupContext, Ref, computed, watch } from "@vue/composition-api";
 import { MetricProps, ComparisonMetricData, Metric } from "@/types/metrics";
 import { useDataEvents } from "@/meta/events";
 import {
@@ -12,6 +12,12 @@ export function useLineChartComponent(
   props: MetricProps,
   context: SetupContext
 ): ComparisonMetricData {
+  watch(
+    () => context.root.$metricController.maxValueData[props.metric],
+    (prev, next) => {
+      console.log("max2", prev, next);
+    }
+  );
   return {
     data: context.root.$metricController.data[props.metric],
     chartConfiguration: getMetricChartConfiguration(props.metric),

--- a/hyrisecockpit/frontend/src/meta/components.ts
+++ b/hyrisecockpit/frontend/src/meta/components.ts
@@ -12,12 +12,6 @@ export function useLineChartComponent(
   props: MetricProps,
   context: SetupContext
 ): ComparisonMetricData {
-  watch(
-    () => context.root.$metricController.maxValueData[props.metric],
-    (prev, next) => {
-      console.log("max2", prev, next);
-    }
-  );
   return {
     data: context.root.$metricController.data[props.metric],
     chartConfiguration: getMetricChartConfiguration(props.metric),

--- a/hyrisecockpit/frontend/src/meta/components.ts
+++ b/hyrisecockpit/frontend/src/meta/components.ts
@@ -30,9 +30,11 @@ const metricEventMap: Partial<Record<Metric, (data: any) => void>> = {
   storage: emitStorageDataChangedEvent
 };
 
-export function useUpdatingData(data: any, metric: Metric): void {
-  if (Object.keys(data).length) {
-    if (metricEventMap[metric]) metricEventMap[metric]!(data);
+export function useUpdatingData(data: any, metrics: Metric[]): void {
+  if (Object.values(data).length) {
+    metrics.forEach(metric => {
+      if (metricEventMap[metric]) metricEventMap[metric]!(data);
+    });
   }
 }
 

--- a/hyrisecockpit/frontend/src/meta/metrics.ts
+++ b/hyrisecockpit/frontend/src/meta/metrics.ts
@@ -68,6 +68,16 @@ const metricsMetadata: Record<Metric, MetricMetadata> = {
     dataType: "interval",
     historic: false
   },
+  memoryFootprint: {
+    fetchType: "modify",
+    transformationService: useDataTransformation("memoryFootprint"),
+    base: "storage",
+    endpoint: monitorBackend + "storage",
+    component: "MemoryFootprint",
+    requestTime: 1000,
+    dataType: "interval",
+    historic: true
+  },
   queueLength: {
     fetchType: "modify",
     transformationService: useDataTransformation("queueLength"),
@@ -151,6 +161,11 @@ const metricsChartConfiguration: Record<Metric, ChartConfiguration> = {
     xaxis: "Workload",
     yaxis: "Proportion of queries in %"
   },
+  memoryFootprint: {
+    title: "Memory Footprint",
+    xaxis: timeLabel,
+    yaxis: "Memory Footprint in MB"
+  },
   latency: {
     title: "Latency",
     xaxis: timeLabel,
@@ -176,7 +191,7 @@ const metricsChartConfiguration: Record<Metric, ChartConfiguration> = {
   }
 };
 
-const metricDescription: Record<Metric, string> = {
+const metricDescription: Partial<Record<Metric, string>> = {
   access:
     "Number of accesses  <br/> separated by chunk and column  <br/> of the selected table.",
   cpu: "Current processor workload.",
@@ -205,6 +220,11 @@ const metricDetailsConfiguration: Partial<Record<
     border: 100,
     unit: "ms",
     stateOrder: getMetricValueStateOrder("asc")
+  },
+  memoryFootprint: {
+    border: 1,
+    unit: "MB",
+    stateOrder: getMetricValueStateOrder("desc")
   },
   queueLength: {
     border: 20000,
@@ -264,7 +284,7 @@ export function getMetricChartConfiguration(
 }
 
 export function getMetricDescription(metric: Metric): string {
-  return metricDescription[metric];
+  return metricDescription[metric]!;
 }
 
 export function getMetricDetailsConfiguration(

--- a/hyrisecockpit/frontend/src/services/transformationService.ts
+++ b/hyrisecockpit/frontend/src/services/transformationService.ts
@@ -319,12 +319,12 @@ export function usePluginTransformationSevice(): any {
     return data.reduce((result: string[], currentDatabase: any) => {
       return currentDatabase.plugins
         ? [
-          ...result,
-          ...currentDatabase.plugins.map(
-            (plugin: string) =>
-              currentDatabase.id + "_" + plugin.replace("Plugin", "")
-          )
-        ]
+            ...result,
+            ...currentDatabase.plugins.map(
+              (plugin: string) =>
+                currentDatabase.id + "_" + plugin.replace("Plugin", "")
+            )
+          ]
         : result;
     }, []);
   }
@@ -358,9 +358,9 @@ export function usePluginTransformationSevice(): any {
             );
             allSettings[pluginName]
               ? (allSettings[pluginName] = [
-                ...allSettings[pluginName],
-                currentSetting
-              ])
+                  ...allSettings[pluginName],
+                  currentSetting
+                ])
               : (allSettings[pluginName] = [currentSetting]);
             return allSettings;
           },

--- a/hyrisecockpit/frontend/src/services/transformationService.ts
+++ b/hyrisecockpit/frontend/src/services/transformationService.ts
@@ -14,6 +14,7 @@ const transformationServiceMap: Record<Metric, TransformationService> = {
   latency: getLatencyData,
   executedQueryTypeProportion: getExecutedQueryTypeProportionData,
   generatedQueryTypeProportion: getGeneratedQueryTypeProportionData,
+  memoryFootprint: getMemoryFootprint,
   queueLength: getReadOnlyData,
   ram: getRAMData,
   storage: getStorageData,
@@ -21,6 +22,10 @@ const transformationServiceMap: Record<Metric, TransformationService> = {
 };
 
 const { roundNumber } = useFormatting();
+const {
+  getTableMemoryFootprint,
+  getDatabaseMemoryFootprint
+} = useDataTransformationHelpers();
 
 export function useDataTransformation(metric: Metric): TransformationService {
   return transformationServiceMap[metric];
@@ -107,12 +112,11 @@ function getLatencyData(data: any, primaryKey: string = ""): number[] {
   );
 }
 
-function getStorageData(data: any, primaryKey: string = ""): StorageData {
-  const {
-    getTableMemoryFootprint,
-    getDatabaseMemoryFootprint
-  } = useDataTransformationHelpers();
+function getMemoryFootprint(data: any): number[] {
+  return [getDatabaseMemoryFootprint(data)];
+}
 
+function getStorageData(data: any, primaryKey: string = ""): StorageData {
   //TODO: this can be replaced when the size entry of the returned data of every table is fixed from the backend
   const totalDatabaseMemory = getDatabaseMemoryFootprint(data[primaryKey]);
 
@@ -315,12 +319,12 @@ export function usePluginTransformationSevice(): any {
     return data.reduce((result: string[], currentDatabase: any) => {
       return currentDatabase.plugins
         ? [
-            ...result,
-            ...currentDatabase.plugins.map(
-              (plugin: string) =>
-                currentDatabase.id + "_" + plugin.replace("Plugin", "")
-            )
-          ]
+          ...result,
+          ...currentDatabase.plugins.map(
+            (plugin: string) =>
+              currentDatabase.id + "_" + plugin.replace("Plugin", "")
+          )
+        ]
         : result;
     }, []);
   }
@@ -354,9 +358,9 @@ export function usePluginTransformationSevice(): any {
             );
             allSettings[pluginName]
               ? (allSettings[pluginName] = [
-                  ...allSettings[pluginName],
-                  currentSetting
-                ])
+                ...allSettings[pluginName],
+                currentSetting
+              ])
               : (allSettings[pluginName] = [currentSetting]);
             return allSettings;
           },

--- a/hyrisecockpit/frontend/src/types/charts.ts
+++ b/hyrisecockpit/frontend/src/types/charts.ts
@@ -1,4 +1,4 @@
-import { ChartConfiguration } from "./metrics";
+import { ChartConfiguration, Metric } from "./metrics";
 
 export interface ChartProps {
   selectedDatabases: string[];

--- a/hyrisecockpit/frontend/src/types/metrics.ts
+++ b/hyrisecockpit/frontend/src/types/metrics.ts
@@ -12,7 +12,8 @@ export type Metric =
   | "ram"
   | "queueLength"
   | "executedQueryTypeProportion"
-  | "generatedQueryTypeProportion";
+  | "generatedQueryTypeProportion"
+  | "memoryFootprint";
 
 export interface MetricController {
   data: Record<Metric, Ref<any>>;
@@ -30,7 +31,8 @@ export const availableMetrics: Metric[] = [
   "ram",
   "queueLength",
   "executedQueryTypeProportion",
-  "generatedQueryTypeProportion"
+  "generatedQueryTypeProportion",
+  "memoryFootprint"
 ];
 
 export const instanceMetrics: Metric[] = ["storage", "access"];
@@ -41,6 +43,7 @@ export const comparisonMetrics: Metric[] = [
   "queueLength",
   "cpu",
   "ram",
+  "memoryFootprint",
   "storage",
   "access",
   "executedQueryTypeProportion"
@@ -50,7 +53,8 @@ export const overviewMetrics: Metric[] = [
   "latency",
   "queueLength",
   "cpu",
-  "ram"
+  "ram",
+  "memoryFootprint"
 ];
 
 export const workloadMetrics: Metric[] = ["generatedQueryTypeProportion"];

--- a/hyrisecockpit/frontend/src/types/services.ts
+++ b/hyrisecockpit/frontend/src/types/services.ts
@@ -1,10 +1,11 @@
 import { Ref } from "@vue/composition-api";
 import { Workload } from "./workloads";
+import { Metric } from "./metrics";
 
 export interface MetricService {
   data: Ref<any>;
   getDataIfReady: (start?: Date, end?: Date) => void;
-  maxValue: Ref<Number>;
+  maxValues: Ref<Record<Metric, number>>;
   timestamps: Ref<any>;
 }
 

--- a/hyrisecockpit/frontend/src/types/services.ts
+++ b/hyrisecockpit/frontend/src/types/services.ts
@@ -3,7 +3,7 @@ import { Workload } from "./workloads";
 import { Metric } from "./metrics";
 
 export interface MetricService {
-  data: Ref<any>;
+  data: any;
   getDataIfReady: (start?: Date, end?: Date) => void;
   maxValues: Ref<Record<Metric, number>>;
   timestamps: Ref<any>;

--- a/hyrisecockpit/frontend/src/types/services.ts
+++ b/hyrisecockpit/frontend/src/types/services.ts
@@ -5,7 +5,7 @@ import { Metric } from "./metrics";
 export interface MetricService {
   data: any;
   getDataIfReady: (start?: Date, end?: Date) => void;
-  maxValues: Ref<Record<Metric, number>>;
+  maxValues: Record<Metric, number>;
   timestamps: Ref<any>;
 }
 

--- a/hyrisecockpit/frontend/tests/e2e/specs/metrics/helpers.ts
+++ b/hyrisecockpit/frontend/tests/e2e/specs/metrics/helpers.ts
@@ -1,5 +1,6 @@
 import { getSelectorByConfig, roundNumber } from "../helpers";
 import { testDateFormatting, testMaxDecimalDigits } from "../abstractTests";
+import { getDatabaseMemoryFootprint } from "../databases/helpers";
 
 const selectors: Record<string, { element: string; title: string }> = {
   throughput: { element: "div", title: "throughput" },
@@ -15,6 +16,7 @@ const selectors: Record<string, { element: string; title: string }> = {
     element: "div",
     title: "generatedQueryTypeProportion"
   },
+  memoryFootprint: { element: "div", title: "memoryFootprint" },
   firstStorage: { element: "div", title: "1storage" },
   secondStorage: { element: "div", title: "2storage" },
   firstAccess: { element: "div", title: "1access" },
@@ -61,9 +63,10 @@ export function assertDataRequest(url: string, range: number): void {
 export function assertLineChartData(
   chartDatasets: any[],
   requestData: any,
-  databases: any[]
+  databases: any[],
+  perIndex: boolean = false
 ): void {
-  databases.forEach((database: any) => {
+  databases.forEach((database: any, idx) => {
     const chartData: any = chartDatasets.find(
       (data: any) => data.name === database
     );
@@ -76,7 +79,11 @@ export function assertLineChartData(
     });
 
     chartData.y.forEach((item: any) => {
-      expect(item).to.eq(requestData[database]);
+      if (perIndex) {
+        expect(item).to.eq(requestData[idx]);
+      } else {
+        expect(item).to.eq(requestData[database]);
+      }
     });
   });
 }

--- a/hyrisecockpit/frontend/tests/e2e/specs/metrics/historicalData.spec.ts
+++ b/hyrisecockpit/frontend/tests/e2e/specs/metrics/historicalData.spec.ts
@@ -52,7 +52,7 @@ describe("requesting cpu and ram data", () => {
   });
 });
 
-// test cpu and ram
+// test memory footprint
 describe("requesting memory footprint data", () => {
   beforeEach(() => {
     cy.setupAppState(backend);

--- a/hyrisecockpit/frontend/tests/e2e/specs/metrics/historicalData.spec.ts
+++ b/hyrisecockpit/frontend/tests/e2e/specs/metrics/historicalData.spec.ts
@@ -24,16 +24,8 @@ describe("requesting cpu and ram data", () => {
       cy.get("@" + getGetAlias("system")).then((xhr: any) => {
         assertDataRequest(xhr.url, 30);
       });
-      cy.wait("@" + getGetAlias("system"));
-      cy.get("@" + getGetAlias("system")).then((xhr: any) => {
-        assertDataRequest(xhr.url, 30);
-      });
       cy.wait(1500);
       // test current data
-      cy.wait("@" + getGetAlias("system"));
-      cy.get("@" + getGetAlias("system")).then((xhr: any) => {
-        assertDataRequest(xhr.url, 1);
-      });
       cy.wait("@" + getGetAlias("system"));
       cy.get("@" + getGetAlias("system")).then((xhr: any) => {
         assertDataRequest(xhr.url, 1);
@@ -50,18 +42,56 @@ describe("requesting cpu and ram data", () => {
       cy.get("@" + getGetAlias("system")).then((xhr: any) => {
         assertDataRequest(xhr.url, 30);
       });
-      cy.wait("@" + getGetAlias("system"));
-      cy.get("@" + getGetAlias("system")).then((xhr: any) => {
-        assertDataRequest(xhr.url, 30);
-      });
       cy.wait(1500);
       // test current data
       cy.wait("@" + getGetAlias("system"));
       cy.get("@" + getGetAlias("system")).then((xhr: any) => {
         assertDataRequest(xhr.url, 1);
       });
-      cy.wait("@" + getGetAlias("system"));
-      cy.get("@" + getGetAlias("system")).then((xhr: any) => {
+    });
+  });
+});
+
+// test cpu and ram
+describe("requesting memory footprint data", () => {
+  beforeEach(() => {
+    cy.setupAppState(backend);
+    cy.wait("@" + getGetAlias("storage"));
+    cy.wait(1500);
+    waitForChartRender();
+  });
+
+  // test on comparison
+  describe("visiting comparison page", () => {
+    it("will request the corect time range", () => {
+      cy.visit(getRoute("comparison"));
+      // test historic data
+      cy.wait("@" + getGetAlias("storage"));
+      cy.get("@" + getGetAlias("storage")).then((xhr: any) => {
+        assertDataRequest(xhr.url, 30);
+      });
+      cy.wait(1500);
+      // test current data
+      cy.wait("@" + getGetAlias("storage"));
+      cy.get("@" + getGetAlias("storage")).then((xhr: any) => {
+        assertDataRequest(xhr.url, 1);
+      });
+    });
+  });
+
+  // test on overview
+  describe("visiting overview page", () => {
+    it("will request the corect time range", () => {
+      cy.visit(getRoute("overview"));
+      // test historic data
+      cy.wait("@" + getGetAlias("storage"));
+      cy.get("@" + getGetAlias("storage")).then((xhr: any) => {
+        assertDataRequest(xhr.url, 30);
+      });
+      cy.wait(1500);
+      // test current data
+      cy.wait("@" + getGetAlias("storage"));
+      cy.get("@" + getGetAlias("storage")).then((xhr: any) => {
         assertDataRequest(xhr.url, 1);
       });
     });

--- a/hyrisecockpit/frontend/tests/e2e/specs/metrics/memoryFootprint.spec.ts
+++ b/hyrisecockpit/frontend/tests/e2e/specs/metrics/memoryFootprint.spec.ts
@@ -1,0 +1,113 @@
+import { useBackendMock } from "../../setup/backendMock";
+import { getRoute } from "../views/helpers";
+import {
+  getSelector,
+  getSelectorWithID,
+  getDetailsSelectorWithID,
+  assertMetricDetails,
+  assertLineChartData
+} from "./helpers";
+import { waitForChartRender } from "../helpers";
+import { getDatabaseMemoryFootprint } from "../databases/helpers";
+
+const backend = useBackendMock();
+
+let databases: any[] = [];
+let data: any = {};
+
+// test on overview
+describe("visiting the overview page", () => {
+  before(() => {
+    cy.setupAppState(backend).then((xhr: any) => {
+      databases = xhr.response.body;
+    });
+    cy.visit(getRoute("overview"));
+    cy.setupData("storage").then((xhr: any) => {
+      data = Object.values(xhr.response.body.body.storage).map(entry =>
+        getDatabaseMemoryFootprint(entry)
+      );
+    });
+    waitForChartRender();
+  });
+
+  // test data
+  it("will show the correct metric data", () => {
+    cy.get(getSelector("memoryFootprint")).should((elements: any) => {
+      assertLineChartData(
+        elements[0].data,
+        data,
+        databases.map(db => db.id),
+        true
+      );
+    });
+  });
+
+  // test layout
+  it("will show the correct range and title", () => {
+    cy.get(getSelector("memoryFootprint")).should((elements: any) => {
+      const layout = elements[0].layout;
+      expect(layout.yaxis.title.text).to.eq("Memory Footprint in MB");
+      expect(layout.yaxis.range[0]).to.eq(0);
+    });
+  });
+
+  // test details
+  it("will not show metric details", () => {
+    databases.forEach((database: any) => {
+      cy.get(getDetailsSelectorWithID("memoryFootprint", database.id)).should(
+        "not.exist"
+      );
+    });
+  });
+});
+
+// test on comparison
+describe("visiting the comparison page", () => {
+  before(() => {
+    cy.setupAppState(backend).then((xhr: any) => {
+      databases = xhr.response.body;
+    });
+    cy.visit(getRoute("comparison"));
+    cy.setupData("storage").then((xhr: any) => {
+      data = Object.values(xhr.response.body.body.storage).map(entry =>
+        getDatabaseMemoryFootprint(entry)
+      );
+    });
+    waitForChartRender();
+  });
+
+  // test data
+  it("will show the correct metric data", () => {
+    databases.forEach((database: any) => {
+      cy.get(getSelectorWithID("memoryFootprint", database.id)).should(
+        (elements: any) => {
+          assertLineChartData(elements[0].data, data, [database.id], true);
+        }
+      );
+    });
+  });
+
+  // test layout
+  it("will show the correct range and title", () => {
+    databases.forEach((database: any) => {
+      cy.get(getSelectorWithID("memoryFootprint", database.id)).should(
+        (elements: any) => {
+          const layout = elements[0].layout;
+          expect(layout.yaxis.title.text).to.eq("Memory Footprint in MB");
+          expect(layout.yaxis.range[0]).to.eq(0);
+        }
+      );
+    });
+  });
+
+  // test details
+  it("will show the correct metric detail data", () => {
+    databases.forEach((database: any, idx) => {
+      cy.get(getDetailsSelectorWithID("memoryFootprint", database.id))
+        .invoke("text")
+        .then((text: any) => {
+          assertMetricDetails(text, data[idx]);
+        });
+    });
+  });
+});


### PR DESCRIPTION
# Resolves #510

**Does your pull request solve a problem? Please describe:**  
This PR adds a memory footprint chart, and ensures only fetching an endpoint once, also when multiple metrics have the same endpoint.

**NOTE:** There is no historical data for the storage endpoint yet

**Affected Component(s):**  
`Frontend`
