### PR TITLE
B/quick fix update plugin log

### DIFF
--- a/hyrisecockpit/database_manager/background_scheduler.py
+++ b/hyrisecockpit/database_manager/background_scheduler.py
@@ -241,7 +241,7 @@ class BackgroundJobManager(object):
 
     def _update_plugin_log(self) -> None:
         """Update plugin log."""
-        log_df = self._sql_to_data_frame("SELECT * FROM meta_log;", None,)
+        log_df = self._sql_to_data_frame("SELECT * FROM meta_log;", None)
 
         if log_df.empty:
             return

--- a/hyrisecockpit/database_manager/background_scheduler.py
+++ b/hyrisecockpit/database_manager/background_scheduler.py
@@ -241,7 +241,13 @@ class BackgroundJobManager(object):
 
     def _update_plugin_log(self) -> None:
         """Update plugin log."""
-        log_df = self._sql_to_data_frame("SELECT * FROM meta_log;", None)
+        endts = int(time_ns() / 1_000_000)  # timestamps in hyrise are in ms-precision
+        startts = endts - 5_000
+
+        log_df = self._sql_to_data_frame(
+            """SELECT * FROM meta_log WHERE "timestamp" >= %s AND "timestamp" < %s;""",
+            params=(startts, endts),
+        )
 
         if log_df.empty:
             return

--- a/hyrisecockpit/database_manager/background_scheduler.py
+++ b/hyrisecockpit/database_manager/background_scheduler.py
@@ -241,13 +241,7 @@ class BackgroundJobManager(object):
 
     def _update_plugin_log(self) -> None:
         """Update plugin log."""
-        endts = time_ns()
-        startts = endts - 2_000_000_000
-
-        log_df = self._sql_to_data_frame(
-            "SELECT * FROM meta_log WHERE 'timestamp' >= %s AND 'timestamp' < %s;",
-            params=(startts, endts),
-        )
+        log_df = self._sql_to_data_frame("SELECT * FROM meta_log;", None,)
 
         if log_df.empty:
             return


### PR DESCRIPTION
# Resolves #number

**Does your pull request solve a problem? Please describe:**  
Hyrise uses ms-precision timestamps for plugin logs. So, the query needs to be adjusted.
Moreover, the syntax for attribute access in Hyrise is `"attribute"` instead of `'attribute'`. 

**Does your pull request add a feature? Please describe:**  
No feature added.

**Affected Component(s):**  
`BackgroundScheduler`

**Additional context:**  
