### PR TITLE
Fix stop workload

### DIFF
--- a/hyrisecockpit/api/app/workload/service.py
+++ b/hyrisecockpit/api/app/workload/service.py
@@ -88,7 +88,7 @@ class WorkloadService:
         if response["header"]["status"] == 200:
             response = cls._send_message_to_gen(
                 Request(
-                    header=Header(message="delete workload"),
+                    header=Header(message="stop workload"),
                     body={"folder_name": folder_name},
                 ),
             )

--- a/tests/api/workload/test_service.py
+++ b/tests/api/workload/test_service.py
@@ -131,7 +131,7 @@ class TestWorkloadService:
         )
         service._send_message_to_gen.assert_called_once_with(  # type: ignore
             Request(
-                header=Header(message="delete workload"),
+                header=Header(message="stop workload"),
                 body={"folder_name": detailed_interface["folder_name"]},
             )
         )
@@ -152,7 +152,7 @@ class TestWorkloadService:
         )
         service._send_message_to_gen.assert_called_once_with(  # type: ignore
             Request(
-                header=Header(message="delete workload"),
+                header=Header(message="stop workload"),
                 body={"folder_name": detailed_interface["folder_name"]},
             )
         )


### PR DESCRIPTION
Co-authored-by: Alexander Dubrawski <dubrawski.alexander@googlemail.com>

# Resolves bug

**Does your pull request solve a problem? Please describe:**  
`WorkloadGenerator` doesn't have a call `delete workload`. As a consequence, we can't stop the workload execution. The corresponding call in `WorkloadGenerator` is called `stop workload`.

**Does your pull request add a feature? Please describe:**  
No feature added. 

**Affected Component(s):**  
`Api`

**Additional context:**  

