### PR TITLE
Fix PUT on workload

### DIFF
--- a/hyrisecockpit/workload_generator/generator.py
+++ b/hyrisecockpit/workload_generator/generator.py
@@ -135,7 +135,7 @@ class WorkloadGenerator(object):
         else:
             workload.update(new_workload)
             response = get_response(200)
-            response["body"]["folder_name"] = folder_name
+            response["body"]["workload"] = workload
         return response
 
     def _generate_workload(self) -> None:


### PR DESCRIPTION
# Resolves no open issue

**Does your pull request solve a problem? Please describe:**  
`WorkloadGenerator` returned the `folder_name` instead of the `workload`, while the backend expects the `workload`:
https://github.com/hyrise/Cockpit/blob/1479aee73ce4b7bd27f6fbb0c3bf3531c1e97af1/hyrisecockpit/api/app/workload/service.py#L121

**Does your pull request add a feature? Please describe:**  
No.

**Affected Component(s):**  
`WorkloadGenerator`