### PR TITLE
Serialize workload object in response

### DIFF
--- a/hyrisecockpit/workload_generator/generator.py
+++ b/hyrisecockpit/workload_generator/generator.py
@@ -135,7 +135,11 @@ class WorkloadGenerator(object):
         else:
             workload.update(new_workload)
             response = get_response(200)
-            response["body"]["workload"] = workload
+            response["body"]["workload"] = DetailedWorkloadInterface(
+                folder_name=folder_name,
+                frequency=workload.frequency,
+                weights=workload.weights,
+            )
         return response
 
     def _generate_workload(self) -> None:


### PR DESCRIPTION
# Resolves no open issue

**Does your pull request solve a problem? Please describe:**  
The `Workload` returned by the `WorkloadGenerator` when updating a `Workload` was not serialized.

**Does your pull request add a feature? Please describe:**  
No.

**Affected Component(s):**  
`WorkloadGenerator`