### PR TITLE
f/565-heatmap-equality

### DIFF
--- a/hyrisecockpit/frontend/src/components/charts/Heatmap.vue
+++ b/hyrisecockpit/frontend/src/components/charts/Heatmap.vue
@@ -3,12 +3,7 @@
 </template>
 
 <script lang="ts">
-import {
-  defineComponent,
-  SetupContext,
-  onMounted,
-  watch,
-} from "@vue/composition-api";
+import { defineComponent, SetupContext, onMounted } from "@vue/composition-api";
 import Plotly from "@/../plotlyBundle.ts";
 import { ChartConfiguration, AccessData } from "../../types/metrics";
 import { ChartProps, ChartPropsValidation } from "../../types/charts";

--- a/hyrisecockpit/frontend/src/components/metrics/Access.vue
+++ b/hyrisecockpit/frontend/src/components/metrics/Access.vue
@@ -2,9 +2,7 @@
   <div>
     <div>
       <metric-detailed-view>
-        <template #header>
-          Access Frequency
-        </template>
+        <template #header>Access Frequency</template>
         <template #content>
           <v-select
             :id="'1' + 'access-select'"
@@ -22,6 +20,7 @@
             :data="accessData"
             :chart-configuration="chartConfiguration"
             :autosize="false"
+            :max-value="maxValue"
           />
         </template>
       </metric-detailed-view>
@@ -41,6 +40,7 @@
         :chart-configuration="chartConfiguration"
         :selected-databases="selectedDatabases"
         :max-chart-width="maxChartWidth"
+        :max-value="maxValue"
       />
     </div>
   </div>
@@ -74,6 +74,7 @@ interface Data {
   accessData: Ref<AccessData>;
   chartConfiguration: ChartConfiguration;
   selectedTable: Ref<string>;
+  maxValue: Ref<number>;
 }
 
 export default defineComponent({
@@ -107,6 +108,7 @@ export default defineComponent({
       tables: computed(() => watchedDatabase.tables),
       accessData,
       selectedTable,
+      maxValue: context.root.$metricController.maxValueData[props.metric],
     };
   },
 });

--- a/hyrisecockpit/frontend/src/services/metricService.ts
+++ b/hyrisecockpit/frontend/src/services/metricService.ts
@@ -7,6 +7,7 @@ import { getMetricMetadata } from "../meta/metrics";
 import { useFormatting } from "@/meta/formatting";
 import { isInTestMode } from "../../config";
 import Vue from "vue";
+import { useMaxValueHelper } from "./transformationService";
 
 // fetch data for all metrics with same endpoint
 export function useMetricService(
@@ -81,8 +82,12 @@ export function useMetricService(
           data[metric] = result;
         }
         Vue.set(data, metric, JSON.parse(JSON.stringify(data[metric])));
-        if (metricsMetaData[idx].fetchType === "modify")
+        if (metricsMetaData[idx].fetchType === "modify") {
           Vue.set(maxValues, metric, handleMaxValues(data[metric], idx));
+        } else {
+          const getMaxValue = useMaxValueHelper(metric);
+          if (getMaxValue) Vue.set(maxValues, metric, getMaxValue(result));
+        }
       });
 
       const newTimestamps = result[0]?.[metricInfo.base]?.map(

--- a/hyrisecockpit/frontend/src/services/transformationService.ts
+++ b/hyrisecockpit/frontend/src/services/transformationService.ts
@@ -268,6 +268,33 @@ function getAccessData(
   return { chunks, columns, dataByChunks, descriptions };
 }
 
+export function useMaxValueHelper(
+  metric: Metric
+): ((data: any) => number) | undefined {
+  const maxValueHelper: Partial<Record<Metric, (data: any) => number>> = {
+    access: getAccessMaxValue,
+  };
+
+  function getAccessMaxValue(data: any): number {
+    return Object.values(data).reduce((maxValue: number, dbData: any) => {
+      const tableMaxValue = Object.values(dbData).reduce(
+        (maxValue: number, tableData: any) => {
+          const columnMaxValue = Object.values(tableData).reduce(
+            (maxValue: number, columnData: any) =>
+              Math.max(...columnData, maxValue),
+            0
+          );
+          return Math.max(maxValue, columnMaxValue);
+        },
+        0
+      );
+      return Math.max(maxValue, tableMaxValue);
+    }, 0);
+  }
+
+  return maxValueHelper[metric];
+}
+
 export function useDataTransformationHelpers(): {
   getDatabaseMemoryFootprint: (data: any) => number;
   getTableMemoryFootprint: (data: any) => number;


### PR DESCRIPTION
# Resolves #565

**Does your pull request solve a problem? Please describe:**  
This PR adds the possibility to set max values for read-only metric data. This will be used for access frequency to set a max range of the heat map.

![image](https://user-images.githubusercontent.com/49444254/80578236-6f4e5f00-8a08-11ea-8a5d-9e92540b3b6a.png)


**Affected Component(s):**  
`Frontend`

