### PR TITLE
F/start-and-stop-worker

### DIFF
--- a/hyrisecockpit/frontend/devServer/src/server.ts
+++ b/hyrisecockpit/frontend/devServer/src/server.ts
@@ -72,11 +72,13 @@ mockPostRoute("workload/");
 mockPostRoute("plugin", "control");
 mockPostRoute("plugin_settings", "control", true);
 mockPostRoute("sql/", "control");
+mockPostRoute("database/worker", "control", true);
 
 mockDeleteRoute("database/", "control");
 mockDeleteRoute("database/benchmark_tables", "control");
 mockDeleteRoute("workload/*");
 mockDeleteRoute("plugin", "control");
+mockDeleteRoute("database/worker", "control", true);
 
 mockPutRoute("workload/*");
 
@@ -139,14 +141,16 @@ function mockPostRoute(
 
 function mockDeleteRoute(
   route: string,
-  backendRoute?: "control" | "monitor"
+  backendRoute?: "control" | "monitor",
+  stub = false
 ): void {
   const request = getRequestOfRoute(route);
   server.delete(getBackendRoute(route, backendRoute), (req, res) => {
     logRequest(req, res);
-    mocks.getMockedDeleteCallback(request)(
-      handleRequestBody(request, req, true)
-    );
+    if (!stub)
+      mocks.getMockedDeleteCallback(request)(
+        handleRequestBody(request, req, true)
+      );
     res.send({});
   });
 }

--- a/hyrisecockpit/frontend/src/components/workload/WorkloadGeneration.vue
+++ b/hyrisecockpit/frontend/src/components/workload/WorkloadGeneration.vue
@@ -147,6 +147,8 @@ function useWorkloadHandler(): WorkloadHandler {
 function useWorkloadAction(workload: Ref<Workload>): WorkloadAction {
   const frequency = ref<number>(200);
   const {
+    startWorker,
+    stopWorker,
     getWorkload,
     getWorkloads,
     startWorkload,
@@ -195,8 +197,10 @@ function useWorkloadAction(workload: Ref<Workload>): WorkloadAction {
     startLoading("start");
     getWorkloads().then((response: any) => {
       if (response.data.length === 0) {
-        startWorkload(workload.value, frequency.value).then(() => {
-          stopLoading("start");
+        startWorker().then(() => {
+          startWorkload(workload.value, frequency.value).then(() => {
+            stopLoading("start");
+          });
         });
       } else {
         updateWorkload(workload.value, frequency.value).then(() => {
@@ -209,8 +213,10 @@ function useWorkloadAction(workload: Ref<Workload>): WorkloadAction {
     startLoading("pause");
     getWorkloads().then((response: any) => {
       if (response.data.length === 0) {
-        startWorkload(workload.value, 0).then(() => {
-          stopLoading("pause");
+        startWorker().then(() => {
+          startWorkload(workload.value, 0).then(() => {
+            stopLoading("pause");
+          });
         });
       } else {
         updateWorkload(workload.value, 0).then(() => {
@@ -224,6 +230,7 @@ function useWorkloadAction(workload: Ref<Workload>): WorkloadAction {
     getWorkloads().then((response: any) => {
       if (response.data.length !== 0) {
         stopWorkload(workload.value).then(() => {
+          stopWorker();
           stopLoading("stop");
         });
       }

--- a/hyrisecockpit/frontend/src/services/workloadService.ts
+++ b/hyrisecockpit/frontend/src/services/workloadService.ts
@@ -21,6 +21,13 @@ export function useWorkloadService(): WorkloadService {
     });
   }
 
+  async function startWorker(): Promise<void> {
+    return axios.post(`${controlBackend}database/worker`);
+  }
+  async function stopWorker(): Promise<void> {
+    return axios.delete(`${controlBackend}database/worker`);
+  }
+
   async function getWorkload(workload: Workload): Promise<void> {
     return axios.get(`${workloadBackend}${getTransferredWorkload(workload)}`);
   }
@@ -56,6 +63,8 @@ export function useWorkloadService(): WorkloadService {
     getLoadedWorkloadData,
     loadWorkloadData,
     deleteWorkloadData,
+    startWorker,
+    stopWorker,
     getWorkload,
     getWorkloads,
     startWorkload,

--- a/hyrisecockpit/frontend/src/types/services.ts
+++ b/hyrisecockpit/frontend/src/types/services.ts
@@ -36,6 +36,8 @@ export interface WorkloadService {
   getLoadedWorkloadData: () => Promise<string[]>;
   loadWorkloadData: (workload: Workload) => Promise<void>;
   deleteWorkloadData: (workload: Workload) => Promise<void>;
+  startWorker: () => Promise<void>;
+  stopWorker: () => Promise<void>;
   getWorkload: (workload: Workload) => Promise<void>;
   getWorkloads: () => Promise<void>;
   startWorkload: (workload: Workload, frequency: number) => Promise<void>;

--- a/hyrisecockpit/frontend/tests/e2e/setup/backendMock.ts
+++ b/hyrisecockpit/frontend/tests/e2e/setup/backendMock.ts
@@ -117,6 +117,9 @@ export function useBackendMock(
       getPostAlias("workload")
     );
     cy.route("POST", getRequestRoute("sql", "post")).as(getPostAlias("sql"));
+    cy.route("POST", getRequestRoute("worker", "post")).as(
+      getPostAlias("worker")
+    );
 
     /* DELETE */
     cy.route("DELETE", getRequestRoute("database", "delete")).as(
@@ -130,6 +133,9 @@ export function useBackendMock(
     );
     cy.route("DELETE", getRequestRoute("workload", "delete")).as(
       getDeleteAlias("workload")
+    );
+    cy.route("DELETE", getRequestRoute("worker", "delete")).as(
+      getDeleteAlias("worker")
     );
 
     /* PUT */
@@ -295,6 +301,7 @@ export function mockBackend(
     );
     mock(getRequestRoute("workload", "post"), getPostAlias("workload"));
     mock(getRequestRoute("sql", "post"), getPostAlias("sql"));
+    mock(getRequestRoute("worker", "post"), getPostAlias("worker"));
   }
 
   function mockDeleteRoutes(mock: RouteMockFunction): void {
@@ -305,6 +312,7 @@ export function mockBackend(
     );
     mock(getRequestRoute("plugin", "delete"), getDeleteAlias("plugin"));
     mock(getRequestRoute("workload", "delete"), getDeleteAlias("workload"));
+    mock(getRequestRoute("worker", "delete"), getDeleteAlias("worker"));
   }
 
   return {

--- a/hyrisecockpit/frontend/tests/e2e/setup/helpers.ts
+++ b/hyrisecockpit/frontend/tests/e2e/setup/helpers.ts
@@ -30,7 +30,8 @@ export type Request =
   | "plugin_log"
   | "workload"
   | "status"
-  | "sql";
+  | "sql"
+  | "worker";
 
 export type BackendState = "up" | "down";
 
@@ -100,6 +101,10 @@ const requestRoutes: Record<
     put: "**/workload/**",
   },
   sql: { post: "**/control/sql/" },
+  worker: {
+    post: "**/control/database/worker",
+    delete: "**/control/database/worker",
+  },
 };
 
 export function getRequestRoute(
@@ -135,6 +140,7 @@ const postAliases: Partial<Record<Request, string>> = {
   plugin_settings: "setPluginSettings",
   workload: "startWorkload",
   sql: "sendSQL",
+  worker: "startWorker",
 };
 
 const deleteAliases: Partial<Record<Request, string>> = {
@@ -142,6 +148,7 @@ const deleteAliases: Partial<Record<Request, string>> = {
   benchmark_tables: "removeTables",
   plugin: "deactivatePlugin",
   workload: "stopWorkload",
+  worker: "stopWorker",
 };
 
 const putAliases: Partial<Record<Request, string>> = {

--- a/hyrisecockpit/frontend/tests/e2e/specs/workloadGeneration/workloadGeneration.spec.ts
+++ b/hyrisecockpit/frontend/tests/e2e/specs/workloadGeneration/workloadGeneration.spec.ts
@@ -66,10 +66,13 @@ describe("opening workload generation", () => {
         .check({ force: true });
       cy.get(getSelector("startButton")).click();
 
+      cy.wait("@" + getPostAlias("worker"));
       cy.wait("@" + getPostAlias("workload"));
       cy.get("@" + getPostAlias("workload")).should((xhr: any) => {
         assertStartedWorkload(xhr.request.body, activeBenchmark);
       });
+
+      cy.numberOfRequests(getPostAlias("worker")).should("eq", 1);
       cy.numberOfRequests(getPostAlias("workload")).should("eq", 1);
 
       // update tmp state
@@ -91,7 +94,9 @@ describe("opening workload generation", () => {
 
       cy.get(getSelector("stopButton")).click();
 
+      cy.wait("@" + getDeleteAlias("worker"));
       cy.wait("@" + getDeleteAlias("workload"));
+      cy.numberOfRequests(getDeleteAlias("worker")).should("eq", 1);
       cy.numberOfRequests(getDeleteAlias("workload")).should("eq", 1);
 
       // update tmp state
@@ -173,10 +178,14 @@ describe("opening workload generation", () => {
         .eq(getBenchmarkIndex(activeBenchmark))
         .check({ force: true });
       cy.get(getSelector("startButton")).click();
+
+      cy.wait("@" + getPostAlias("worker"));
       cy.wait("@" + getPostAlias("workload"));
       cy.get("@" + getPostAlias("workload")).should((xhr: any) => {
         assertStartedWorkload(xhr.request.body, activeBenchmark);
       });
+
+      cy.numberOfRequests(getPostAlias("worker")).should("eq", 1);
       cy.numberOfRequests(getPostAlias("workload")).should("eq", 1);
 
       clickElement(getViewSelector("workloadGenerationButton"));


### PR DESCRIPTION
# Resolves #number

**Does your pull request solve a problem? Please describe:**  
The workers will now be started and stopped in the frontend because the backend seperates worker and workload generation logic.

**Affected Component(s):**  
`Frontend`
