### PR TITLE
Autobuild image to branch

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -41,7 +41,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      uses: docker/build-push-action@v1
+    - uses: docker/build-push-action@v1
       with:
         username: ${{ secrets.DOCKER_HUB_USERNAME }}
         password: ${{ secrets.DOCKER_HUB_TOKEN }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -36,6 +36,48 @@ jobs:
     - name: Check logs Frontend
       run: docker logs cockpit_frontend_1
 
+  backend_push:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - uses: docker/build-push-action@v1
+      with:
+        username: ${{ secrets.DOCKER_HUB_USERNAME }}
+        password: ${{ secrets.DOCKER_HUB_TOKEN }}
+        repository: udopigorsch/cockpit-backend
+        tag_with_ref: true
+        dockerfile: ./hyrisecockpit/api/Dockerfile
+
+  generator_push:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - uses: docker/build-push-action@v1
+      with:
+        username: ${{ secrets.DOCKER_HUB_USERNAME }}
+        password: ${{ secrets.DOCKER_HUB_TOKEN }}
+        repository: udopigorsch/cockpit-generator
+        tag_with_ref: true
+        dockerfile: ./hyrisecockpit/workload_generator/Dockerfile
+        
+  manager_push:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - uses: docker/build-push-action@v1
+      with:
+        username: ${{ secrets.DOCKER_HUB_USERNAME }}
+        password: ${{ secrets.DOCKER_HUB_TOKEN }}
+        repository: udopigorsch/cockpit-manager
+        tag_with_ref: true
+        dockerfile: ./hyrisecockpit/database_manager/Dockerfile
+
   frontend_push:
 
     runs-on: ubuntu-latest

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -47,5 +47,5 @@ jobs:
         password: ${{ secrets.DOCKER_HUB_TOKEN }}
         repository: udopigorsch/cockpit-frontend
         tag_with_ref: true
-        dockerfile: {path}/hyrisecockpit/frontend/Dockerfile
+        dockerfile: ./hyrisecockpit/frontend/Dockerfile
   

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -41,11 +41,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+    - uses: actions/checkout@v2
     - uses: docker/build-push-action@v1
       with:
         username: ${{ secrets.DOCKER_HUB_USERNAME }}
         password: ${{ secrets.DOCKER_HUB_TOKEN }}
         repository: udopigorsch/cockpit-frontend
         tag_with_ref: true
-        dockerfile: Cockpit/hyrisecockpit/frontend/Dockerfile
+        dockerfile: ./hyrisecockpit/frontend/Dockerfile
   

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -47,5 +47,5 @@ jobs:
         password: ${{ secrets.DOCKER_HUB_TOKEN }}
         repository: udopigorsch/cockpit-frontend
         tag_with_ref: true
-        dockerfile: ./hyrisecockpit/frontend/Dockerfile
+        dockerfile: {path}/hyrisecockpit/frontend/Dockerfile
   

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -47,5 +47,5 @@ jobs:
         password: ${{ secrets.DOCKER_HUB_TOKEN }}
         repository: udopigorsch/cockpit-frontend
         tag_with_ref: true
-        dockerfile: ./hyrisecockpit/frontend/Dockerfile
+        dockerfile: Cockpit/hyrisecockpit/frontend/Dockerfile
   


### PR DESCRIPTION
**Does your pull request add a feature? Please describe:**  
The enriched Github Action `Docker CI` will now also push the resulting Docker images to the Docker registry.
This will help us to automate the different development setups in a clear and predictable way.

**Affected Component(s):**  
`Docker`

**Additional context:**  
The images will be tagged based on the branch - e.g. cockpit-backend:dev or cockpit-backend:experiemental_branch123.
A push to the master branch and the resulting build will tag the image with latest.
