### PR TITLE
Provide operator data

### DIFF
--- a/hyrisecockpit/api/app/monitor/app.py
+++ b/hyrisecockpit/api/app/monitor/app.py
@@ -876,3 +876,23 @@ class ProcessTableStatus(Resource):
         return _send_message(
             db_manager_socket, Request(header=Header(message="status"), body={}),
         )["body"]["status"]
+
+
+@api.route("/operator")
+class OperatorData(Resource):
+    """Operator information of all databases."""
+
+    def get(self) -> List[Dict]:
+        """Return operator metadata."""
+        operator_data: List[Dict] = []
+        active_databases = _get_active_databases()
+        for database in active_databases:
+            database_data: Dict = {"id": database, "operator_data": []}
+            result = storage_connection.query(
+                'SELECT LAST("operator_data") FROM operator_data', database=database,
+            )
+            operator_rows = list(result["operator_data", None])
+            if len(operator_rows) > 0:
+                database_data["operator_data"] = loads(operator_rows[0]["last"])
+            operator_data.append(database_data)
+        return operator_data

--- a/hyrisecockpit/database_manager/background_scheduler.py
+++ b/hyrisecockpit/database_manager/background_scheduler.py
@@ -12,6 +12,7 @@ from .job.load_tables import load_tables as load_tables_job
 from .job.ping_hyrise import ping_hyrise
 from .job.update_chunks_data import update_chunks_data
 from .job.update_krueger_data import update_krueger_data
+from .job.update_operator_data import update_operator_data
 from .job.update_plugin_log import update_plugin_log
 from .job.update_queue_length import update_queue_length
 from .job.update_storage_data import update_storage_data
@@ -101,6 +102,16 @@ class BackgroundJobManager(object):
             seconds=5,
             args=(self._storage_connection_factory,),
         )
+        self._update_operator_data_job = self._scheduler.add_job(
+            func=update_operator_data,
+            trigger="interval",
+            seconds=5,
+            args=(
+                self._database_blocked,
+                self._connection_factory,
+                self._storage_connection_factory,
+            ),
+        )
 
     def start(self) -> None:
         """Start background scheduler."""
@@ -114,6 +125,7 @@ class BackgroundJobManager(object):
         self._update_storage_data_job.remove()
         self._update_plugin_log_job.remove()
         self._update_queue_length_job.remove()
+        self._update_operator_data_job.remove()
         self._ping_hyrise_job.remove()
         self._scheduler.shutdown()
 

--- a/hyrisecockpit/database_manager/job/update_operator_data.py
+++ b/hyrisecockpit/database_manager/job/update_operator_data.py
@@ -1,0 +1,30 @@
+"""Job for updating the operator data."""
+
+from json import dumps
+from time import time_ns
+
+from hyrisecockpit.database_manager.cursor import StorageConnectionFactory
+from hyrisecockpit.database_manager.job.sql_to_data_frame import sql_to_data_frame
+
+
+def update_operator_data(
+    database_blocked,
+    connection_factory,
+    storage_connection_factory: StorageConnectionFactory,
+) -> None:
+    """Update operator data."""
+    time_stamp = time_ns()
+
+    sql = """SELECT operator, SUM(frequency*walltime_ns) AS total_time_ns
+        FROM meta_cached_operators JOIN meta_cached_queries
+        ON meta_cached_operators.statement_hash=meta_cached_queries.statement_hash
+        GROUP BY operator;"""
+    meta_segments = sql_to_data_frame(database_blocked, connection_factory, sql, None)
+
+    with storage_connection_factory.create_cursor() as log:
+        output = []
+        if not meta_segments.empty:
+            output = list(meta_segments.to_dict("index").values())
+        log.log_meta_information(
+            "operator_data", {"operator_data": dumps(output)}, time_stamp
+        )

--- a/hyrisecockpit/database_manager/job/update_operator_data.py
+++ b/hyrisecockpit/database_manager/job/update_operator_data.py
@@ -17,7 +17,7 @@ def update_operator_data(
 
     sql = """SELECT operator, SUM(frequency*walltime_ns) AS total_time_ns
         FROM meta_cached_operators JOIN meta_cached_queries
-        ON meta_cached_operators.statement_hash=meta_cached_queries.statement_hash
+        ON meta_cached_operators.query_hash=meta_cached_queries.hash_value
         GROUP BY operator;"""
     meta_segments = sql_to_data_frame(database_blocked, connection_factory, sql, None)
 

--- a/system_tests/test_system.py
+++ b/system_tests/test_system.py
@@ -295,6 +295,13 @@ class TestSystem:
         assert response.status_code == 200  # nosec
         assert response.json()["header"]["status"] == 200  # nosec
 
+    def test_gets_operator_data(self):
+        """Test getting of the operator data."""
+        response = self.backend.get_property("monitor/operator")
+        assert response.status_code == 200  # nosec
+        assert len(response.json()) > 0  # nosec
+        assert len(response.json()[0]["operator_data"]) > 0  # nosec
+
     def test_stops_workload_generator(self):
         """Test stopping of the workload generator."""
         response = self.backend.stop_workload("tpch_0_1")

--- a/tests/database_manager/job/test_update_operator_data.py
+++ b/tests/database_manager/job/test_update_operator_data.py
@@ -1,0 +1,47 @@
+"""Tests for the update operator data job."""
+from json import dumps
+from unittest.mock import patch
+
+from pandas import DataFrame
+
+from hyrisecockpit.cross_platform_support.testing_support import MagicMock
+from hyrisecockpit.database_manager.job.update_operator_data import update_operator_data
+
+
+class TestUpdateOperatorDataJob:
+    """Tests update operator data job."""
+
+    @patch("hyrisecockpit.database_manager.job.update_operator_data.sql_to_data_frame")
+    @patch(
+        "hyrisecockpit.database_manager.job.update_operator_data.time_ns", lambda: 42
+    )
+    def test_logs_operator_data(self, mock_sql_to_data_frame: MagicMock,) -> None:
+        """Test logging of the operator data."""
+        fake_storage_df: DataFrame = DataFrame(
+            {
+                "operator": ["Projection", "TableWrapper"],
+                "total_time_ns": [2060976830, 61949034],
+            }
+        )
+        mock_sql_to_data_frame.return_value = fake_storage_df
+
+        mock_cursor = MagicMock()
+        mock_storage_connection_factory = MagicMock()
+        mock_storage_connection_factory.create_cursor.return_value.__enter__.return_value = (
+            mock_cursor
+        )
+
+        mock_database_blocked = False
+        mock_connection_factory = MagicMock()
+
+        update_operator_data(
+            mock_database_blocked,
+            mock_connection_factory,
+            mock_storage_connection_factory,
+        )
+
+        expected_output = list(fake_storage_df.to_dict("index").values())
+
+        mock_cursor.log_meta_information.assert_called_with(
+            "operator_data", {"operator_data": dumps(expected_output)}, 42
+        )

--- a/tests/database_manager/test_background_scheduler.py
+++ b/tests/database_manager/test_background_scheduler.py
@@ -193,6 +193,7 @@ class TestBackgroundJobManager:
         background_job_manager._update_plugin_log_job = MagicMock()
         background_job_manager._ping_hyrise_job = MagicMock()
         background_job_manager._update_queue_length_job = MagicMock()
+        background_job_manager._update_operator_data_job = MagicMock()
 
         background_job_manager.close()
 
@@ -203,6 +204,7 @@ class TestBackgroundJobManager:
         background_job_manager._update_plugin_log_job.remove.assert_called_once()
         background_job_manager._ping_hyrise_job.remove.assert_called_once()
         background_job_manager._update_queue_length_job.remove.assert_called_once()
+        background_job_manager._update_operator_data_job.remove.assert_called_once()
         mock_scheduler.shutdown.assert_called_once()
 
     def test_successfully_start_loading_tables(


### PR DESCRIPTION
# Resolves #613

**Does your pull request solve a problem? Please describe:**  
Now, we are able to retrieve the detailed information about executed operators from the Hyrise cache.

**Does your pull request add a feature? Please describe:**  
Provide information about executed operators.

**Affected Component(s):**  
`App`, `BackgroundScheduler`

**Additional context:**  

