### PR TITLE
fix bug - broken metric tile

### DIFF
--- a/hyrisecockpit/frontend/src/components/charts/Treemap.vue
+++ b/hyrisecockpit/frontend/src/components/charts/Treemap.vue
@@ -115,6 +115,6 @@ function useTreemapConfiguration(
 </script>
 <style>
 .treemap {
-  margin: 1% 1% 3% 10%;
+  margin: 1% 1% 0% 10%;
 }
 </style>

--- a/hyrisecockpit/frontend/src/components/metrics/Storage.vue
+++ b/hyrisecockpit/frontend/src/components/metrics/Storage.vue
@@ -2,7 +2,7 @@
   <div>
     <metric-detailed-view>
       <template #header>
-        Storage
+        Data Size - Overview
       </template>
       <template #content>
         <Treemap


### PR DESCRIPTION
# Resolves #619 

**Does your pull request solve a problem? Please describe:**  
There was unwanted space between two metrics on the comparison page.

**Does your pull request add a feature? Please describe:**  
Removed margin bottom from treemap.

**Affected Component(s):**  
`Frontend`

**Additional context:**  
See screenshot in issue.
