### PR TITLE
B/adjust plugin log

### DIFF
--- a/hyrisecockpit/api/app/control/app.py
+++ b/hyrisecockpit/api/app/control/app.py
@@ -236,7 +236,7 @@ class PluginLog(Resource):
                 "id": database,
                 "plugin_log": [
                     {
-                        "timestamp": row["timestamp"],
+                        "timestamp": int(row["timestamp"]),
                         "reporter": row["reporter"],
                         "message": row["message"],
                         "level": row["level"],

--- a/tests/database_manager/job/test_update_plugin_log.py
+++ b/tests/database_manager/job/test_update_plugin_log.py
@@ -1,5 +1,6 @@
 """Tests for the update plug-in log job."""
 
+from datetime import datetime
 from typing import List, Tuple
 from unittest.mock import patch
 
@@ -17,8 +18,12 @@ class TestUpdatePluginLogJob:
 
     @patch("hyrisecockpit.database_manager.job.update_plugin_log.sql_to_data_frame")
     @patch(
-        "hyrisecockpit.database_manager.job.update_plugin_log.time_ns",
-        lambda: 1_000_000,
+        "hyrisecockpit.database_manager.job.update_plugin_log.time",
+        lambda: 1_000_000.0,
+    )
+    @patch(
+        "hyrisecockpit.database_manager.job.update_plugin_log._datetime_str_to_unix_timestamp",
+        lambda x: 10,
     )
     def test_logs_plugin_log(self, mock_sql_to_data_frame: MagicMock) -> None:
         """Test logs plugin log."""
@@ -29,7 +34,7 @@ class TestUpdatePluginLogJob:
         )
         fake_not_empty_data_frame: DataFrame = DataFrame(
             {
-                "timestamp": [0, 42],
+                "timestamp": ["2020-05-15 14:12:24", "2020-05-15 14:25:24"],
                 "reporter": ["KeepHyriseRunning", "HyrisePleaseStayAlive"],
                 "message": ["error", "error"],
                 "log_level": ["Warning", "Warning"],
@@ -44,22 +49,25 @@ class TestUpdatePluginLogJob:
         )
 
         expected_function_argument: List[Tuple[int, str, str, str]] = [
-            (0, "KeepHyriseRunning", "error", "Warning"),
-            (42, "HyrisePleaseStayAlive", "error", "Warning"),
+            (10, "KeepHyriseRunning", "error", "Warning"),
+            (10, "HyrisePleaseStayAlive", "error", "Warning"),
         ]
+
+        expected_startts = str(datetime.fromtimestamp(1_000_000.0 - 5.0))
+        expected_endts = str(datetime.fromtimestamp(1_000_000.0))
 
         mock_sql_to_data_frame.assert_called_once_with(
             fake_database_blocked,
             fake_connection_factory,
             """SELECT * FROM meta_log WHERE "timestamp" >= %s AND "timestamp" < %s;""",
-            params=(-4999, 1),
+            params=(expected_startts, expected_endts),
         )
         mock_cursor.log_plugin_log.assert_called_once_with(expected_function_argument)
 
     @patch("hyrisecockpit.database_manager.job.update_plugin_log.sql_to_data_frame")
     @patch(
-        "hyrisecockpit.database_manager.job.update_plugin_log.time_ns",
-        lambda: 1_000_000,
+        "hyrisecockpit.database_manager.job.update_plugin_log.time",
+        lambda: 1_000_000.0,
     )
     def test_doesnt_log_plugin_log_when_empty(
         self, mock_sql_to_data_frame: MagicMock


### PR DESCRIPTION
# Resolves #number

**Does your pull request solve a problem? Please describe:**  
The new version of Hyrise provides plugin logs with the timestamps in `'%Y-%m-%d %H:%M:%S'` format. So, the backend should be adjusted accordingly.

**Does your pull request add a feature? Please describe:**  
No feature added.

**Affected Component(s):**  
`BackgroundScheduler`

**Additional context:**  