### PR TITLE
Change query for getting loaded tables 

### DIFF
--- a/hyrisecockpit/database_manager/database.py
+++ b/hyrisecockpit/database_manager/database.py
@@ -144,7 +144,7 @@ class Database(object):
         """Return already loaded tables."""
         try:
             with self._connection_factory.create_cursor() as cur:
-                cur.execute("show tables;", None)
+                cur.execute("select * from meta_tables;", None)
                 rows = cur.fetchall()
         except (DatabaseError, InterfaceError):
             return []

--- a/hyrisecockpit/database_manager/job/get_loaded_tables.py
+++ b/hyrisecockpit/database_manager/job/get_loaded_tables.py
@@ -11,7 +11,7 @@ def get_loaded_tables_for_scale_factor(
     loaded_tables: List = []
     try:
         with connection_factory.create_cursor() as cur:
-            cur.execute("show tables;", None)
+            cur.execute("select * from meta_tables;", None)
             results = cur.fetchall()
             all_loaded_tables = [row[0] for row in results] if results else []
             for table in tables:

--- a/tests/database_manager/test_database.py
+++ b/tests/database_manager/test_database.py
@@ -335,7 +335,7 @@ class TestDatabase(object):
 
         results = database.get_loaded_tables()
 
-        mock_cursor.execute.assert_called_once_with("show tables;", None)
+        mock_cursor.execute.assert_called_once_with("select * from meta_tables;", None)
         assert results == ["hallo", "world"]  # type: ignore
 
     @mark.parametrize(
@@ -360,7 +360,7 @@ class TestDatabase(object):
 
         results = database.get_loaded_tables()
 
-        mock_cursor.execute.assert_called_once_with("show tables;", None)
+        mock_cursor.execute.assert_called_once_with("select * from meta_tables;", None)
         assert results == []
 
     def test_gets_hyrise_active(self, database: Database) -> None:


### PR DESCRIPTION
# Resolves #634

**Does your pull request solve a problem? Please describe:**  
We are now getting the correct state of the loaded tables.

**Affected Component(s):**  
`Database`, `Job.get_loaded_tables`, ...

