### PR TITLE
B/add real kruegerdata

### DIFF
--- a/hyrisecockpit/api/app/monitor/app.py
+++ b/hyrisecockpit/api/app/monitor/app.py
@@ -842,19 +842,18 @@ class KruegerData(Resource):
         active_databases = _get_active_databases()
         for database in active_databases:
             result = storage_connection.query(
-                'SELECT LAST("executed"), * FROM krueger_data', database=database,
+                'SELECT LAST("krueger_data"), * FROM krueger_data', database=database,
             )
-            krueger_data_value = list(result["krueger_data", None])
-            if len(krueger_data_value) > 0:
+            krueger_data_values = list(result["krueger_data", None])
+            if len(krueger_data_values) > 0:
                 krueger_data.append(
                     {
                         "id": database,
-                        "executed": loads(krueger_data_value[0]["executed"]),
-                        "generated": loads(krueger_data_value[0]["generated"]),
+                        "krueger_data": loads(krueger_data_values[0]["last"]),
                     }
                 )
             else:
-                krueger_data.append({"id": database, "executed": {}, "generated": {}})
+                krueger_data.append({"id": database, "krueger_data": []})
         return krueger_data
 
 

--- a/hyrisecockpit/database_manager/background_scheduler.py
+++ b/hyrisecockpit/database_manager/background_scheduler.py
@@ -100,7 +100,11 @@ class BackgroundJobManager(object):
             func=update_krueger_data,
             trigger="interval",
             seconds=5,
-            args=(self._storage_connection_factory,),
+            args=(
+                self._database_blocked,
+                self._connection_factory,
+                self._storage_connection_factory,
+            ),
         )
         self._update_operator_data_job = self._scheduler.add_job(
             func=update_operator_data,

--- a/hyrisecockpit/database_manager/job/update_krueger_data.py
+++ b/hyrisecockpit/database_manager/job/update_krueger_data.py
@@ -2,31 +2,56 @@
 
 from json import dumps
 from time import time_ns
+from typing import Dict, List
 
 from hyrisecockpit.database_manager.cursor import StorageConnectionFactory
+from hyrisecockpit.database_manager.job.sql_to_data_frame import sql_to_data_frame
 
 
-def update_krueger_data(storage_connection_factory: StorageConnectionFactory) -> None:
+def update_krueger_data(
+    database_blocked,
+    connection_factory,
+    storage_connection_factory: StorageConnectionFactory,
+) -> None:
     """Update krueger data."""
     time_stamp = time_ns()
-    executed_mocked_data = {
-        "SELECT": 100,
-        "INSERT": 0,
-        "UPDATE": 0,
-        "DELETE": 0,
+    sql = """WITH query_latency AS (SELECT SUM(walltime_ns) AS latency, query_hash
+        FROM meta_cached_operators
+        GROUP BY query_hash)
+        SELECT hash_value, latency, frequency, sql_string FROM query_latency JOIN meta_cached_queries
+        ON query_latency.query_hash = meta_cached_queries.hash_value;"""
+
+    meta_segments = sql_to_data_frame(database_blocked, connection_factory, sql, None)
+
+    counts: Dict = {  # (total_latency, total_frequency)
+        "SELECT": (0, 0),
+        "CREATE": (0, 0),
+        "UPDATE": (0, 0),
+        "INSERT": (0, 0),
+        "DELETE": (0, 0),
+        "COPY": (0, 0),
     }
-    generated_mocked_data = {
-        "SELECT": 100,
-        "INSERT": 0,
-        "UPDATE": 0,
-        "DELETE": 0,
-    }
+
+    if not meta_segments.empty:
+        for _, row in meta_segments.iterrows():
+            for query_type in counts.keys():
+                if row["sql_string"].startswith(query_type):
+                    counts[query_type] = (
+                        counts[query_type][0] + row["latency"],
+                        counts[query_type][1] + row["frequency"],
+                    )
+                    break
+
+    krueger_data: List = [
+        {
+            "query_type": query_type,
+            "total_latency": total_latency,
+            "total_frequency": total_frequency,
+        }
+        for query_type, (total_latency, total_frequency) in counts.items()
+    ]
+
     with storage_connection_factory.create_cursor() as log:
         log.log_meta_information(
-            "krueger_data",
-            {
-                "executed": dumps(executed_mocked_data),
-                "generated": dumps(generated_mocked_data),
-            },
-            time_stamp,
+            "krueger_data", {"krueger_data": dumps(krueger_data)}, time_stamp,
         )

--- a/hyrisecockpit/database_manager/job/update_krueger_data.py
+++ b/hyrisecockpit/database_manager/job/update_krueger_data.py
@@ -29,18 +29,30 @@ def update_krueger_data(
         "UPDATE": (0, 0),
         "INSERT": (0, 0),
         "DELETE": (0, 0),
+        "DROP": (0, 0),
         "COPY": (0, 0),
     }
 
+    other_count = (0, 0)
+
     if not meta_segments.empty:
         for _, row in meta_segments.iterrows():
+            type_found = False
             for query_type in counts.keys():
                 if row["sql_string"].startswith(query_type):
                     counts[query_type] = (
                         counts[query_type][0] + row["latency"],
                         counts[query_type][1] + row["frequency"],
                     )
+                    type_found = True
                     break
+            if not type_found:
+                other_count = (
+                    other_count[0] + row["latency"],
+                    other_count[1] + row["frequency"],
+                )
+
+    counts["OTHER"] = other_count
 
     krueger_data: List = [
         {

--- a/tests/database_manager/job/test_update_krueger_data.py
+++ b/tests/database_manager/job/test_update_krueger_data.py
@@ -1,0 +1,69 @@
+"""Tests for the update krueger data job."""
+
+from json import dumps
+from unittest.mock import patch
+
+from pandas import DataFrame
+
+from hyrisecockpit.cross_platform_support.testing_support import MagicMock
+from hyrisecockpit.database_manager.job.update_krueger_data import update_krueger_data
+
+
+class TestUpdateKruegerData:
+    """Tests for the update krueger data job."""
+
+    @patch("hyrisecockpit.database_manager.job.update_krueger_data.time_ns", lambda: 42)
+    @patch("hyrisecockpit.database_manager.job.update_krueger_data.sql_to_data_frame")
+    def test_logs_updated_krueger_data(self, mock_sql_to_data_frame: MagicMock) -> None:
+        """Test logs updated krueger data."""
+        data = {
+            "sql_string": [
+                "SELECT happiness;",
+                "DROP problems;",
+                "CREATE mood;",
+                "COPY copyshop;",
+                "SOME weird stuff;",
+            ],
+            "latency": [10, 20, 30, 40, 50],
+            "frequency": [10, 20, 30, 40, 50],
+        }
+
+        mock_sql_to_data_frame.return_value = DataFrame(data)
+
+        mock_cursor = MagicMock()
+        mock_storage_connection_factory = MagicMock()
+        mock_storage_connection_factory.create_cursor.return_value.__enter__.return_value = (
+            mock_cursor
+        )
+        mock_database_blocked = False
+        mock_connection_factory = MagicMock()
+
+        expected_sql = """WITH query_latency AS (SELECT SUM(walltime_ns) AS latency, query_hash
+        FROM meta_cached_operators
+        GROUP BY query_hash)
+        SELECT hash_value, latency, frequency, sql_string FROM query_latency JOIN meta_cached_queries
+        ON query_latency.query_hash = meta_cached_queries.hash_value;"""
+
+        expected_krueger_data = [
+            {"query_type": "SELECT", "total_latency": 10, "total_frequency": 10},
+            {"query_type": "CREATE", "total_latency": 30, "total_frequency": 30},
+            {"query_type": "UPDATE", "total_latency": 0, "total_frequency": 0},
+            {"query_type": "INSERT", "total_latency": 0, "total_frequency": 0},
+            {"query_type": "DELETE", "total_latency": 0, "total_frequency": 0},
+            {"query_type": "DROP", "total_latency": 20, "total_frequency": 20},
+            {"query_type": "COPY", "total_latency": 40, "total_frequency": 40},
+            {"query_type": "OTHER", "total_latency": 50, "total_frequency": 50},
+        ]
+
+        update_krueger_data(
+            mock_database_blocked,
+            mock_connection_factory,
+            mock_storage_connection_factory,
+        )
+
+        mock_sql_to_data_frame.assert_called_once_with(
+            mock_database_blocked, mock_connection_factory, expected_sql, None
+        )
+        mock_cursor.log_meta_information.assert_called_once_with(
+            "krueger_data", {"krueger_data": dumps(expected_krueger_data)}, 42
+        )


### PR DESCRIPTION
# Resolves #183

**Does your pull request solve a problem? Please describe:**  
Now, we are able to show the real workload data in the kruegergraph (workload_overview).

**Does your pull request add a feature? Please describe:**  
Example of `/monitor/krueger_data` response:
```
[
  {
    "id": "momentum",
    "krueger_data": [
      {
        "query_type": "SELECT",
        "total_latency": 18121695583,
        "total_frequency": 831
      },
      {
        "query_type": "CREATE",
        "total_latency": 286013,
        "total_frequency": 37
      },
      {
        "query_type": "UPDATE",
        "total_latency": 0,
        "total_frequency": 0
      },
      {
        "query_type": "INSERT",
        "total_latency": 0,
        "total_frequency": 0
      },
      {
        "query_type": "DELETE",
        "total_latency": 0,
        "total_frequency": 0
      },
      {
        "query_type": "DROP",
        "total_latency": 51837,
        "total_frequency": 37
      },
      {
        "query_type": "COPY",
        "total_latency": 2994107353,
        "total_frequency": 8
      },
      {
        "query_type": "OTHER",
        "total_latency": 0,
        "total_frequency": 0
      }
    ]
  }
]
```
**Affected Component(s):**  
`App`, `BackgroundScheduler`

**Additional context:**  