### PR TITLE
Change workload weights from int to float

### DIFF
--- a/hyrisecockpit/api/app/workload/interface.py
+++ b/hyrisecockpit/api/app/workload/interface.py
@@ -12,4 +12,4 @@ class WorkloadInterface(TypedDict):
 class DetailedWorkloadInterface(WorkloadInterface):
     """Detailed interface of a Workload."""
 
-    weights: Dict[str, int]
+    weights: Dict[str, float]

--- a/hyrisecockpit/api/app/workload/model.py
+++ b/hyrisecockpit/api/app/workload/model.py
@@ -14,7 +14,7 @@ class Workload:
 class DetailedWorkload(Workload):
     """Detailed model of a Workload."""
 
-    def __init__(self, folder_name: str, frequency: int, weights: Dict[str, int]):
+    def __init__(self, folder_name: str, frequency: int, weights: Dict[str, float]):
         """Initialize a Workload model."""
-        self.weights: Dict[str, int] = weights
+        self.weights: Dict[str, float] = weights
         super().__init__(folder_name, frequency)

--- a/hyrisecockpit/api/app/workload/schema.py
+++ b/hyrisecockpit/api/app/workload/schema.py
@@ -1,6 +1,6 @@
 """Schema of a Workload."""
 from marshmallow import Schema
-from marshmallow.fields import Dict, Integer, String
+from marshmallow.fields import Dict, Float, Integer, String
 
 
 class WorkloadSchema(Schema):
@@ -20,6 +20,6 @@ class DetailedWorkloadSchema(WorkloadSchema):
 
     weights = Dict(
         keys=String(description="Name of the query."),
-        values=Integer(description="Weight of the query."),
+        values=Float(description="Weight of the query."),
         description="Weights of queries used for generation.",
     )

--- a/hyrisecockpit/workload_generator/workload.py
+++ b/hyrisecockpit/workload_generator/workload.py
@@ -23,8 +23,8 @@ class Workload:
         """Initialize a Workload."""
         self.frequency: int = frequency
         self._queries: OrderedDict[str, List[str]] = OrderedDict(queries)
-        self._weights: OrderedDict[str, int] = OrderedDict(
-            (key, 100) for key in self._queries.keys()
+        self._weights: OrderedDict[str, float] = OrderedDict(
+            (key, 1.0) for key in self._queries.keys()
         )
 
     @property
@@ -39,12 +39,12 @@ class Workload:
         return self._frequency
 
     @property
-    def weights(self) -> Dict[str, int]:
+    def weights(self) -> Dict[str, float]:
         """Get the weight of each query."""
         return dict(self._weights)
 
     @weights.setter
-    def weights(self, values: Dict[str, int]) -> Dict[str, int]:
+    def weights(self, values: Dict[str, float]) -> Dict[str, float]:
         """Set the weight of each query, must be done with all queries."""
         if values.keys() == self._weights.keys():
             for key, value in values.items():
@@ -54,7 +54,7 @@ class Workload:
     @weights.deleter
     def weights(self):
         """Reset the weight of each query."""
-        self._weights = OrderedDict((key, 100) for key in self._queries.keys())
+        self._weights = OrderedDict((key, 1.0) for key in self._queries.keys())
 
     def update(self, new_workload: DetailedWorkloadInterface) -> None:
         """Update a Workload with new attributes."""

--- a/tests/api/workload/data.py
+++ b/tests/api/workload/data.py
@@ -11,7 +11,7 @@ from hyrisecockpit.api.app.workload.model import DetailedWorkload, Workload
 
 __folder_names = ["tpch_0.1", "job"]
 __frequencies = [0, 420]
-__weights: Tuple[Dict[str, int], ...] = ({}, {"01": 0, "23c": 101})
+__weights: Tuple[Dict[str, float], ...] = ({}, {"01": 0.0, "23c": 100.1})
 
 
 def interfaces() -> List[WorkloadInterface]:

--- a/tests/api/workload/test_interface.py
+++ b/tests/api/workload/test_interface.py
@@ -22,7 +22,7 @@ def frequency(request) -> int:
     return request.param
 
 
-@fixture(params=[{}, {"01": 0, "23c": 101}])
+@fixture(params=[{}, {"01": 0.0, "23c": 100.1}])
 def weights(request) -> Dict[str, int]:
     """Get examples of weights."""
     return request.param
@@ -36,7 +36,7 @@ def interface(folder_name: str, frequency: int) -> WorkloadInterface:
 
 @fixture
 def detailed_interface(
-    folder_name: str, frequency: int, weights: Dict[str, int]
+    folder_name: str, frequency: int, weights: Dict[str, float]
 ) -> DetailedWorkloadInterface:
     """Return a real DetailedWorkload model."""
     return DetailedWorkloadInterface(

--- a/tests/api/workload/test_model.py
+++ b/tests/api/workload/test_model.py
@@ -18,8 +18,8 @@ def frequency(request) -> int:
     return request.param
 
 
-@fixture(params=[{}, {"01": 0, "23c": 101}])
-def weights(request) -> Dict[str, int]:
+@fixture(params=[{}, {"01": 0.0, "23c": 100.1}])
+def weights(request) -> Dict[str, float]:
     """Get examples of weights."""
     return request.param
 
@@ -32,7 +32,7 @@ def workload(folder_name: str, frequency: int) -> Workload:
 
 @fixture
 def detailed_workload(
-    folder_name: str, frequency: int, weights: Dict[str, int]
+    folder_name: str, frequency: int, weights: Dict[str, float]
 ) -> Workload:
     """Return a real DetailedWorkload model."""
     return DetailedWorkload(

--- a/tests/api/workload/test_schema.py
+++ b/tests/api/workload/test_schema.py
@@ -24,7 +24,7 @@ def frequency(request) -> int:
     return request.param
 
 
-@fixture(params=[{}, {"01": 0, "23c": 101}])
+@fixture(params=[{}, {"01": 0.0, "23c": 100.1}])
 def weights(request) -> Dict[str, int]:
     """Get examples of weights."""
     return request.param
@@ -86,7 +86,7 @@ class TestDetailedWorkloadSchema:
         detailed_schema: DetailedWorkloadSchema,
         folder_name: str,
         frequency: int,
-        weights: Dict[str, int],
+        weights: Dict[str, float],
     ):
         """A DetailedWorkload schema can create a DetailedWorkload model."""
         interface: DetailedWorkloadInterface = {
@@ -105,7 +105,7 @@ class TestDetailedWorkloadSchema:
         detailed_schema: DetailedWorkloadSchema,
         folder_name: str,
         frequency: int,
-        weights: Dict[str, int],
+        weights: Dict[str, float],
     ):
         """A DetailedWorkload model can be serialized with a DetailedWorkload schema."""
         interface: DetailedWorkloadInterface = {


### PR DESCRIPTION
# Addresses https://github.com/hyrise/Cockpit/pull/604#issuecomment-627374133

**Does your pull request solve a problem? Please describe:**  
Workload query weights were `int`, now they are `float`.
Default weights were `100`, now they are `1.0`.

**Does your pull request add a feature? Please describe:**  
No.

**Affected Component(s):**  
`CockpitBackend`'s namespace `/workload`, `WorkloadGenerator`