### PR TITLE
Add watchtower directly

### DIFF
--- a/docker-compose.deployment.yml
+++ b/docker-compose.deployment.yml
@@ -38,3 +38,9 @@ services:
     ports:
       - "5432:5432"
       
+  watchtower:
+    image: containrrr/watchtower
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - /root/.docker/config.json:/config.json
+    command: --interval 30


### PR DESCRIPTION
**Does your pull request solve a problem? Please describe:**  
We use watchtower to automatically pull current Docker images and restart the depending container. At this time watchtower is started separately .

**Does your pull request add a feature? Please describe:**  
Including watchtower into the deployment definition will lead to an easier setup and decrease  possible human mistakes.

**Affected Component(s):**  
`Docker`