### PR TITLE
Remove need for Frontend ports & Improve Autoupdate

### DIFF
--- a/docker-compose.deployment.yml
+++ b/docker-compose.deployment.yml
@@ -22,7 +22,7 @@ services:
   frontend:
     image: udopigorsch/cockpit-frontend:latest
     ports:
-      - "5000:5000"
+      - "80:5000"
 
   influxdb:
     image: influxdb:alpine
@@ -39,8 +39,12 @@ services:
       - "5432:5432"
       
   watchtower:
+    environmanet:
+      - WATCHTOWER_CLEANUP=1
+      - WATCHTOWER_INCLUDE_STOPPED=1
+      - WATCHTOWER_REVIVE_STOPPED=1
+      - WATCHTOWER_POLL_INTERVAL=30
     image: containrrr/watchtower
-    volumes:
+    volumes: 
       - /var/run/docker.sock:/var/run/docker.sock
       - /root/.docker/config.json:/config.json
-    command: --interval 30

--- a/docker-compose.deployment.yml
+++ b/docker-compose.deployment.yml
@@ -5,11 +5,14 @@ services:
     image: udopigorsch/cockpit-backend:latest
     ports:
       - "8000:8000"
+    restart: unless-stopped
 
   manager:
     image: udopigorsch/cockpit-manager:latest
     ports:
       - "8001:8001"
+    restart: unless-stopped
+
     
   generator:
     image: udopigorsch/cockpit-generator:latest
@@ -18,11 +21,15 @@ services:
     ports:
       - "8002:8002"
       - "8003:8003"
+    restart: unless-stopped
+
 
   frontend:
     image: udopigorsch/cockpit-frontend:latest
     ports:
       - "80:5000"
+    restart: unless-stopped
+
 
   influxdb:
     image: influxdb:alpine
@@ -30,6 +37,8 @@ services:
       - ./influxdb:/var/lib/influxdb
     ports:
       - "8086:8086"
+    restart: unless-stopped
+
 
   hyrise:
     image: udopigorsch/hyrise:bp1920
@@ -37,9 +46,11 @@ services:
       - ./cached_tables:/usr/local/hyrise/cached_tables
     ports:
       - "5432:5432"
+    restart: unless-stopped
+
       
   watchtower:
-    environmanet:
+    environment:
       - WATCHTOWER_CLEANUP=1
       - WATCHTOWER_INCLUDE_STOPPED=1
       - WATCHTOWER_REVIVE_STOPPED=1
@@ -48,3 +59,4 @@ services:
     volumes: 
       - /var/run/docker.sock:/var/run/docker.sock
       - /root/.docker/config.json:/config.json
+    restart: unless-stopped

--- a/hyrise/Dockerfile
+++ b/hyrise/Dockerfile
@@ -21,3 +21,4 @@ RUN cd /usr/local/hyrise-git/cmake-build-release \
     && make CompressionPlugin ClusteringPlugin IndexSelectionPlugin \
     && cp lib/libClusteringPlugin.so lib/libCompressionPlugin.so lib/libIndexSelectionPlugin.so /usr/local/hyrise/lib/ 
 ENTRYPOINT ["/usr/local/hyrise/hyriseServer"]
+EXPOSE 5432

--- a/hyrise/hooks/build
+++ b/hyrise/hooks/build
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+docker build --build-arg ARCHITECTURE=$ARCHITECTURE BRANCH=$BRANCH -f $DOCKERFILE_PATH -t $IMAGE_NAME


### PR DESCRIPTION
**Does your pull request solve a problem? Please describe:**  
Currently the Frontend uses the same port used by our system surveilance, blocking one another.
Additionally old images wont get deleted.

**Does your pull request add a feature? Please describe:**  
Moving our forntend to port 80 via Docker routing solves the double use of port 5000 and makes it more convenient to access it - vm-example.address:5000 becomes vm-example.address.
Watchtower will also be able to cleanup now. 

**Affected Component(s):**  
`Docker`, `Frontend`