### PR TITLE
F/fix-workload-settings-and-equalizer

### DIFF
--- a/hyrisecockpit/frontend/src/components/workload/Equalizer.vue
+++ b/hyrisecockpit/frontend/src/components/workload/Equalizer.vue
@@ -151,7 +151,8 @@ export default defineComponent({
               });
           }
         );
-      }
+      },
+      { immediate: true }
     );
     watch(
       () => props.selectedWorkloads,
@@ -159,7 +160,8 @@ export default defineComponent({
         panels.value = Object.keys(props.selectedWorkloads).map((index) =>
           parseInt(index)
         );
-      }
+      },
+      { immediate: true }
     );
     return {
       weights,

--- a/hyrisecockpit/frontend/src/components/workload/FrequencyHandler.vue
+++ b/hyrisecockpit/frontend/src/components/workload/FrequencyHandler.vue
@@ -69,7 +69,8 @@ export default defineComponent({
       () => props.initialFrequencies,
       () => {
         frequencies.value = props.initialFrequencies;
-      }
+      },
+      { immediate: true }
     );
     return {
       frequencies,

--- a/hyrisecockpit/frontend/src/components/workload/WorkloadSelector.vue
+++ b/hyrisecockpit/frontend/src/components/workload/WorkloadSelector.vue
@@ -58,7 +58,8 @@ export default defineComponent({
       () => props.selectedWorkloads,
       () => {
         workloads.value = props.selectedWorkloads;
-      }
+      },
+      { immediate: true }
     );
     return {
       workloads,


### PR DESCRIPTION
# Resolves #number

**Does your pull request solve a problem? Please describe:**  
After updating the dependencies the frequencies and the equalizer were not shown properly. Moreover, after reloading the page the started workloads were not marked in the checkboxes.

**Affected Component(s):**  
`Frontend`

**Additional context:**  
This is how the workload settings look before the fix:
<img width="904" alt="FrequenciesBug" src="https://user-images.githubusercontent.com/49514526/87537210-8eb96780-c69a-11ea-97dd-7d2a485db89b.png">
<img width="905" alt="EqualizerBug" src="https://user-images.githubusercontent.com/49514526/87537212-90832b00-c69a-11ea-8a10-895b69c0b9a1.png">
