### PR TITLE
F/688-change-dialog-for-adding-databases

### DIFF
--- a/hyrisecockpit/frontend/src/components/databases/AddDatabase.vue
+++ b/hyrisecockpit/frontend/src/components/databases/AddDatabase.vue
@@ -51,11 +51,10 @@
           </v-col>
         </v-row>
       </v-card-text>
-      <v-card-actions class="pt-0">
-        <v-spacer></v-spacer>
+      <v-card-actions class="justify-center pt-0">
         <v-btn
-          color="primary"
-          text
+          class="secondary primary--text mb-3"
+          small
           @click="
             createNewDatabase();
             closeDialog();

--- a/hyrisecockpit/frontend/src/components/databases/AddDatabase.vue
+++ b/hyrisecockpit/frontend/src/components/databases/AddDatabase.vue
@@ -4,99 +4,50 @@
       <v-card-title>
         <span class="headline">Add new database</span>
       </v-card-title>
-      <v-card-text>
-        <v-container>
-          <v-row>
-            <v-col cols="6">
-              <v-text-field
-                v-model="host"
-                label="Host*"
-                required
-                data-id="host-input"
-              ></v-text-field>
-            </v-col>
-            <v-col cols="6">
-              <v-text-field
-                v-model="id"
-                label="Id*"
-                required
-                :error-messages="idError"
-                data-id="id-input"
-              ></v-text-field>
-            </v-col>
-          </v-row>
-          <v-row align="center">
-            <v-col cols="12" sm="6">
-              <v-text-field
-                v-model="number_workers"
-                label="Number of Workers*"
-                type="number"
-                required
-                data-id="worker-input"
-              ></v-text-field>
-            </v-col>
-            <v-spacer />
-            <v-btn
-              text
-              @click="showAdvanced = !showAdvanced"
-              data-id="advanced-input-button"
-            >
-              <div v-if="!showAdvanced">show advanced</div>
-              <div v-else>hide advanced</div>
-            </v-btn>
-          </v-row>
-          <v-expand-transition>
-            <div v-if="showAdvanced">
-              <v-row>
-                <v-col cols="6" sm="6">
-                  <v-text-field
-                    v-model="port"
-                    label="Port*"
-                    required
-                    data-id="port-input"
-                  ></v-text-field>
-                </v-col>
-                <v-col cols="6" sm="6">
-                  <v-text-field
-                    v-model="dbname"
-                    label="Databasename*"
-                    required
-                    data-id="dbname-input"
-                  ></v-text-field>
-                </v-col>
-              </v-row>
-              <v-row>
-                <v-col cols="6">
-                  <v-text-field
-                    v-model="user"
-                    label="User*"
-                    required
-                    data-id="user-input"
-                  ></v-text-field>
-                </v-col>
-                <v-col cols="6">
-                  <v-text-field
-                    v-model="password"
-                    label="Password"
-                    type="password"
-                    data-id="password-input"
-                  ></v-text-field>
-                </v-col>
-              </v-row>
-            </div>
-          </v-expand-transition>
-        </v-container>
-        <small>*indicates required field</small>
+      <v-card-text class="pb-0">
+        <v-row>
+          <v-col cols="6">
+            <v-text-field
+              v-model="host"
+              label="Host"
+              data-id="host-input"
+            ></v-text-field>
+          </v-col>
+          <v-col cols="6">
+            <v-text-field
+              v-model="id"
+              label="ID"
+              :error-messages="idError"
+              data-id="id-input"
+            ></v-text-field>
+          </v-col>
+        </v-row>
+        <v-row>
+          <v-col cols="6">
+            <v-text-field
+              v-model="port"
+              label="Port"
+              data-id="port-input"
+            ></v-text-field>
+          </v-col>
+          <v-col cols="6">
+            <v-text-field
+              v-model="number_workers"
+              label="Number of Workers"
+              type="number"
+              data-id="worker-input"
+            ></v-text-field>
+          </v-col>
+          <v-spacer />
+          <v-btn text data-id="advanced-input-button"> </v-btn>
+        </v-row>
       </v-card-text>
-      <v-card-actions>
+      <v-card-actions class="pt-0">
         <v-spacer></v-spacer>
         <v-btn
           color="primary"
           text
-          @click="
-            closeDialog();
-            showAdvanced = false;
-          "
+          @click="closeDialog()"
           data-id="cancel-add-database-button"
           >Cancel</v-btn
         >
@@ -105,7 +56,6 @@
           text
           @click="
             createNewDatabase();
-            showAdvanced = false;
             closeDialog();
           "
           :disabled="!!idError.length"
@@ -127,13 +77,10 @@ import {
   ref,
   watch,
 } from "@vue/composition-api";
-import { useDatabaseService } from "@/services/databaseService";
+import { useDatabaseService } from "../../services/databaseService";
 
 interface Props {
   open: boolean;
-}
-interface Data extends DatabaseCreationData {
-  showAdvanced: Ref<boolean>;
 }
 
 export default defineComponent({
@@ -143,11 +90,9 @@ export default defineComponent({
       default: false,
     },
   },
-  setup(props: Props, context: SetupContext): Data {
-    const showAdvanced = ref(false);
+  setup(props: Props, context: SetupContext): DatabaseCreationData {
     return {
       ...useDatabaseCreation(context),
-      showAdvanced,
     };
   },
 });

--- a/hyrisecockpit/frontend/src/components/databases/AddDatabase.vue
+++ b/hyrisecockpit/frontend/src/components/databases/AddDatabase.vue
@@ -57,8 +57,7 @@
       </v-card-text>
       <v-card-actions class="justify-center pt-0">
         <v-btn
-          class="secondary primary--text mb-3"
-          small
+          class="secondary primary--text my-2"
           @click="
             createNewDatabase();
             closeDialog();
@@ -88,7 +87,7 @@ import {
   ref,
   watch,
 } from "@vue/composition-api";
-import { useDatabaseService } from "../../services/databaseService";
+import { useDatabaseService } from "@/services/databaseService";
 
 interface Props {
   open: boolean;

--- a/hyrisecockpit/frontend/src/components/databases/AddDatabase.vue
+++ b/hyrisecockpit/frontend/src/components/databases/AddDatabase.vue
@@ -1,19 +1,19 @@
 <template>
-  <v-dialog v-model="open" persistent max-width="600px">
+  <v-dialog v-model="open" persistent max-width="500px">
     <v-card data-id="add-database">
       <v-card-title>
         <span class="headline">Add new database</span>
       </v-card-title>
       <v-card-text class="pb-0">
         <v-row>
-          <v-col cols="6">
+          <v-col class="pb-0" cols="6">
             <v-text-field
               v-model="host"
               label="Host"
               data-id="host-input"
             ></v-text-field>
           </v-col>
-          <v-col cols="6">
+          <v-col class="pb-0" cols="6">
             <v-text-field
               v-model="id"
               label="ID"
@@ -23,14 +23,14 @@
           </v-col>
         </v-row>
         <v-row>
-          <v-col cols="6">
+          <v-col class="py-0" cols="6">
             <v-text-field
               v-model="port"
               label="Port"
               data-id="port-input"
             ></v-text-field>
           </v-col>
-          <v-col cols="6">
+          <v-col class="py-0" cols="6">
             <v-text-field
               v-model="number_workers"
               label="Number of Workers"
@@ -38,8 +38,6 @@
               data-id="worker-input"
             ></v-text-field>
           </v-col>
-          <v-spacer />
-          <v-btn text data-id="advanced-input-button"> </v-btn>
         </v-row>
       </v-card-text>
       <v-card-actions class="pt-0">

--- a/hyrisecockpit/frontend/src/components/databases/AddDatabase.vue
+++ b/hyrisecockpit/frontend/src/components/databases/AddDatabase.vue
@@ -21,6 +21,7 @@
             <v-text-field
               v-model="host"
               label="Host"
+              :error-messages="host.length < 4 ? 'Required' : ''"
               data-id="host-input"
             ></v-text-field>
           </v-col>
@@ -28,7 +29,7 @@
             <v-text-field
               v-model="id"
               label="ID"
-              :error-messages="idError"
+              :error-messages="!id.length ? 'Required' : idError"
               data-id="id-input"
             ></v-text-field>
           </v-col>
@@ -38,6 +39,7 @@
             <v-text-field
               v-model="port"
               label="Port"
+              :error-messages="!port.length ? 'Required' : ''"
               data-id="port-input"
             ></v-text-field>
           </v-col>
@@ -46,6 +48,8 @@
               v-model="number_workers"
               label="Number of Workers"
               type="number"
+              min="1"
+              :error-messages="number_workers.length === 0 ? 'Required' : ''"
               data-id="worker-input"
             ></v-text-field>
           </v-col>
@@ -59,7 +63,13 @@
             createNewDatabase();
             closeDialog();
           "
-          :disabled="!!idError.length"
+          :disabled="
+            !!idError.length ||
+            !host.length ||
+            !id.length ||
+            !port.length ||
+            number_workers.length === 0
+          "
           data-id="save-database-button"
           >Save</v-btn
         >
@@ -132,8 +142,6 @@ function useDatabaseCreation(context: SetupContext): DatabaseCreationData {
       context.root.$databaseController.availableDatabasesById.value.includes(id)
     ) {
       idError.value = "ID is already taken.";
-    } else if (id.length === 0) {
-      idError.value = "Choose an Id";
     } else {
       idError.value = "";
     }

--- a/hyrisecockpit/frontend/src/components/databases/AvailableDatabasesList.vue
+++ b/hyrisecockpit/frontend/src/components/databases/AvailableDatabasesList.vue
@@ -10,7 +10,7 @@
         class="add ml-0"
         rounded
       >
-        <v-text class="text font-weight-regular mr-1">Add</v-text>
+        <div class="text font-weight-regular mr-1">Add</div>
         <v-icon class="mr-2" :size="20">mdi-database-plus</v-icon>
       </v-btn>
       <v-spacer></v-spacer>

--- a/hyrisecockpit/frontend/src/components/databases/SQLEditor.vue
+++ b/hyrisecockpit/frontend/src/components/databases/SQLEditor.vue
@@ -10,7 +10,7 @@
         width="30"
       >
         <v-icon class="mr-2" color="primary" size="18">mdi-file-edit</v-icon>
-        <v-text class="text font-weight-regular">SQL</v-text>
+        <div class="text font-weight-regular">SQL</div>
       </v-btn>
     </template>
     <v-card>

--- a/hyrisecockpit/frontend/tests/e2e/specs/databases/helpers.ts
+++ b/hyrisecockpit/frontend/tests/e2e/specs/databases/helpers.ts
@@ -25,10 +25,7 @@ export const selectors = {
   idInput: getSelectorByCustomConfig("id-input"),
   hostInput: getSelectorByCustomConfig("host-input"),
   portInput: getSelectorByCustomConfig("port-input"),
-  dbNameInput: getSelectorByCustomConfig("dbname-input"),
   workerInput: getSelectorByCustomConfig("worker-input"),
-  userInput: getSelectorByCustomConfig("user-input"),
-  passwordInput: getSelectorByCustomConfig("password-input"),
   databaseDetailsPanel: getSelectorByCustomConfig("database-details-panel"),
   databaseSystemDetails: getSelectorByCustomConfig("database-system-details"),
   hostDetails: getSelectorByCustomConfig("database-host"),
@@ -47,28 +44,17 @@ export const selectors = {
   sendSQLInput: getSelectorByCustomConfig("send-sql-input"),
 };
 
-export function assertAdvancedPostValues(
+export function assertPostRequest(
   input: DatabaseData,
   requested: DatabaseData
 ): void {
-  expect(input.id).to.eq(requested.id);
+  expect(requested.id).to.eq(requested.id);
   expect(input.host).to.eq(requested.host);
   expect(input.number_workers).to.eq(requested.number_workers);
   expect(input.port).to.eq(requested.port);
-  expect(input.dbname).to.eq(requested.dbname);
 }
 
-export function assertDefaultPostValues(
-  input: DatabaseData,
-  requested: DatabaseData
-): void {
-  expect(input.host).to.eq(requested.host);
-  expect(input.number_workers).to.eq(requested.number_workers);
-  expect(requested.id).to.eq(requested.host);
-  expect(input.host).to.eq(requested.id);
-}
-
-export function assertDeleteValues(
+export function assertDeleteRequest(
   input: string,
   requested: { id: string }
 ): void {

--- a/hyrisecockpit/frontend/tests/e2e/specs/databases/removeDatabase.spec.ts
+++ b/hyrisecockpit/frontend/tests/e2e/specs/databases/removeDatabase.spec.ts
@@ -1,7 +1,7 @@
 import { useBackendMock } from "../../setup/backendMock";
 import { getDeleteAlias } from "../../setup/helpers";
 import { selectors as viewSelectors } from "../views/helpers";
-import { assertDeleteValues, selectors } from "./helpers";
+import { assertDeleteRequest, selectors } from "./helpers";
 
 const backend = useBackendMock({ databases: 2 });
 let databases: any = [];
@@ -85,7 +85,7 @@ describe("When removing a database", () => {
 
       cy.wait("@" + getDeleteAlias("database"));
       cy.get("@" + getDeleteAlias("database")).should((xhr: any) => {
-        assertDeleteValues(removeDatabase, xhr.request.body);
+        assertDeleteRequest(removeDatabase, xhr.request.body);
       });
       cy.numberOfRequests(getDeleteAlias("database")).should("eq", 1);
 


### PR DESCRIPTION
# Resolves #688 

**Does your pull request solve a problem? Please describe:**  
The current dialog for adding databases confuses because of the "Show advanced"-option and too many input fields. This pull request will simplify the dialog.

**Affected Component(s):**  
`Frontend`

**Additional context:**  
Before:
<img width="602" alt="AddDatabaseDialog2" src="https://user-images.githubusercontent.com/49514526/88061343-aba4dd80-cb67-11ea-918e-7ec608ca6a50.png">

After:
<img width="502" alt="AddDatabaseMinimal5" src="https://user-images.githubusercontent.com/49514526/88277705-70c6b500-cce1-11ea-9888-d7d4c009e40f.png">

Form validation:
<img width="503" alt="AddDatabaseMinimalValidation2" src="https://user-images.githubusercontent.com/49514526/88277685-673d4d00-cce1-11ea-9dc1-27d07255d106.png">
