### PR TITLE
f/676-fix-db-value-bug

### DIFF
--- a/hyrisecockpit/frontend/src/controller/databaseController.ts
+++ b/hyrisecockpit/frontend/src/controller/databaseController.ts
@@ -28,8 +28,8 @@ export function useDatabaseController(): DatabaseController {
     }
   });
 
-  eventBus.$on("CPU_DATA_CHANGED", (data: any) => {
-    if (allDatabasesExist(Object.keys(data))) {
+  eventBus.$on("CPU_DATA_CHANGED", (data: any[]) => {
+    if (allDatabasesExist(data.map((entry) => entry.id))) {
       updateDatabaseCPUInformation(data);
     }
   });


### PR DESCRIPTION
# Resolves #676

**Does your pull request solve a problem? Please describe:**  
There was a bug, that the database details for cpu data did not update after adding a new database. 
Unfortunately it takes some time, until the cpu data is loaded in the backend. So it will still show 0 on initial render. Nevertheless there was a bug, that the values were never updated. When the backend finally returns the correct cpu data it will now immediately be used in the frontend.

**Affected Component(s):**  
`Frontend`

