### PR TITLE
Docker/check_for_cached_tables

### DIFF
--- a/docker-compose.deployment.yml
+++ b/docker-compose.deployment.yml
@@ -42,6 +42,8 @@ services:
 
   hyrise:
     image: udopigorsch/hyrise:bp1920
+    healthcheck:
+      test: bash -c [ -f ./cached_tables ]
     volumes:
       - ./cached_tables:/usr/local/hyrise/cached_tables
     ports:


### PR DESCRIPTION
**Does your pull request solve a problem? Please describe:**  
When setting up a naked installation of the cockpit, the cached_tables folder is missing and data thus cannot be loaded (that the UI doesn't complain might become another issue).
One needs to check the hyrise container logs to see that the bin files are missing.

**Does your pull request add a feature? Please describe:**  
This is just a first try (I am a novice with Docker) to get the discussion going. 
I would like to get @cH3n7i 's feedback AFTER he finished TI2.
Another thing I am curious about is whether we should `wget` the files from "somewhere" (let's say archive.org) if the folder does not exist. I'd like to be able to install the cockpit everywhere without access to the VMs storing the bins or the HPI network at all.

Example is stolen from: https://stackoverflow.com/questions/48357244/docker-check-if-file-exists-in-healthcheck

**Affected Component(s):**  
`Docker`