### PR TITLE
Change symbol for detailed plugin description

### DIFF
--- a/hyrisecockpit/frontend/src/components/plugins/PluginSetting.vue
+++ b/hyrisecockpit/frontend/src/components/plugins/PluginSetting.vue
@@ -7,7 +7,7 @@
           v-on="on"
           data-id="setting-help-icon"
           @click="togglePluginEditor()"
-          >mdi-help-circle</v-icon
+          >mdi-information</v-icon
         >
       </template>
       <span data-id="setting-description">{{ setting.description }}</span>


### PR DESCRIPTION
# Resolves #760 

**Does your pull request solve a problem? Please describe:**  
This Pr changes the symbol for the detailed plugin description. I chose the `mdi-information` symbol. We have plenty of alternatives if you are not happy with the symbol https://materialdesignicons.com/cdn/2.0.46/ .
