### PR TITLE
Round decimal notation

### DIFF
--- a/hyrisecockpit/frontend/src/components/metrics/Access.vue
+++ b/hyrisecockpit/frontend/src/components/metrics/Access.vue
@@ -27,7 +27,7 @@
               :chart-configuration="chartConfiguration"
               :autosize="false"
               :max-value="maxValue"
-              :hover-template="'<b>column: %{text}</b> <br><b>chunk: %{y}</b> <br>%{z} accesses <extra></extra>'"
+              :hover-template="'<b>column: %{text}</b> <br><b>chunk: %{y}</b> <br>%{z:.2s} accesses <extra></extra>'"
               :max-chart-width="1300"
             />
           </template>
@@ -54,7 +54,7 @@
       :selected-databases="selectedDatabases"
       :max-chart-width="maxChartWidth"
       :max-value="maxValue"
-      :hover-template="'<b>column: %{text}</b> <br><b>chunk: %{y}</b> <br>%{z} accesses <extra></extra>'"
+      :hover-template="'<b>column: %{text}</b> <br><b>chunk: %{y}</b> <br>%{z:.2s} accesses <extra></extra>'"
     />
   </div>
 </template>


### PR DESCRIPTION
# Resolves #763 

**Does your pull request solve a problem? Please describe:**  
Bevor this PR The access count of the Heatmap wasn't rounded. This PR adjust this issue by using a decimal notation with an SI prefix (https://github.com/d3/d3-format/blob/master/README.md#locale_format).

**Additional context:**  

![Screenshot 2020-09-21 at 15 45 06](https://user-images.githubusercontent.com/32880898/93775066-43837e00-fc22-11ea-9703-424b1f2b4456.png)

