### PR TITLE
Remove e2e from gitHub action

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -14,9 +14,6 @@ jobs:
       - name: Install dependencies
         run: npm install
         working-directory: ./hyrisecockpit/frontend
-      - name: Run e2e tests
-        run: npm run start:dev:ci & npm run test:e2e:headless:stubless
-        working-directory: ./hyrisecockpit/frontend
       - name: Check lint errors
         run: npm run lint > lint-output.txt
         working-directory: ./hyrisecockpit/frontend


### PR DESCRIPTION
Since the e2e test behaved really inconsistent in GitHub actions, this PR removes them from the GitHub action workflow. So the e2e tests are not run after a commit to the repository in GitHub actions. This doesn't mean however they shouldn't be used. It is still possible to run the e2e test on the local machine. 

I created an Issue #781 , so we still try to automate the e2e tests in the future. 